### PR TITLE
feat(gascity-comms): agent-watchdog + gc-warm-rig-pool for spawn gap …

### DIFF
--- a/docs/agent-watchdog.md
+++ b/docs/agent-watchdog.md
@@ -1,0 +1,160 @@
+# Agent watchdog: backstop spawning for rig-scoped agents
+
+Per-city cooldown order that forces a spawn when the supervisor's auto-scale
+path silently skips one despite queued work. Pairs with the warm-pool
+override (`min_active_sessions = 1` per `[[rigs.overrides]]`) so the
+watchdog is a backstop, not the primary scaling engine.
+
+## The bug it works around
+
+The supervisor decides scaling per template (`<rig>/gastown.polecat`,
+`<rig>/gastown.refinery`) on each tick of its reconciler loop. The decision
+log line reads:
+
+```
+poolDesired: <rig>/<template> = N
+scaleCheck:  <rig>/<template> = N
+Woke session '<alias>'
+session lifecycle: op=start outcome=success
+```
+
+When everything works, all four lines fire in order. Two failure modes
+silently break the chain after `poolDesired` — the queue then sits forever
+until a human runs `gc session new <rig>/<template>` manually.
+
+### 1. `poolDesired` flap between consecutive ticks
+
+`poolDesired` is computed by counting beads that match the template. The
+match window changes between consecutive reads (a routed bead briefly has
+`assignee=null` in one read but is claimed by the time the next tick
+samples), so `N` flaps:
+
+```
+poolDesired: traitprint-cloud/gastown.polecat = 2
+poolDesired: traitprint-cloud/gastown.polecat = 1
+scaleCheck:  traitprint-cloud/gastown.polecat = 1
+```
+
+The 2-want is never reflected in a `scaleCheck`, so the second polecat
+never spawns. The queue is implicitly underserved.
+
+### 2. Stale session beads inflate active count
+
+When a session exits without clean reaping, its session bead persists.
+`scaleCheck` counts the stale bead as live and skips a spawn even though
+the tmux session is gone. The reaper logs the cleanup *afterwards*:
+
+```
+WARN reconciler: reaped stale session bead yg-a7n3t — tmux session not found
+```
+
+By the time the bead is reaped, several scaleCheck cycles may have
+declined to spawn.
+
+Both modes are silent: `poolDesired` logs correctly, but no
+`scaleCheck`-then-create follows. Manual `gc session new` works because
+it bypasses `scaleCheck` entirely.
+
+## What this order does
+
+`packs/gascity-comms/orders/agent-watchdog.toml` runs every 30s. For each
+rig listed in `gc config show`, for each scaled template
+(`refinery`, `polecat`):
+
+1. Count queued work — beads routed to `<rig>/gastown.<template>` with
+   no assignee, plus open beads explicitly assigned to that template
+   name.
+2. Count live sessions — `gc session list --state=active --template=...`.
+3. Count *recent* sessions — created within the last 60s (configurable
+   via `AGENT_WATCHDOG_RECENT_CUTOFF`). This guards against racing the
+   reconciler if it's actively materializing one.
+4. Spawn iff `queued > 0 AND live == 0 AND recent == 0`.
+
+Spawning calls `gc session new <full-template> --no-attach` with no
+`--alias`, so the supervisor picks a free name from the namepool.
+Because the script only spawns when `live == 0`, it cannot exceed
+`max_active_sessions` — the live==0 gate means at most one watchdog
+session per template per tick. Subsequent ticks observe `live > 0` and
+skip.
+
+The order processes templates in this order: **refinery first**, then
+polecat. A stalled refinery blocks merge throughput across all polecats
+in the rig, so the spawn budget goes to the refinery first when both
+need help.
+
+## Why this is a backstop, not the primary path
+
+The companion script `packs/gascity-comms/assets/scripts/gc-warm-rig-pool`
+applies `min_active_sessions = 1` to each rig's polecat and refinery via
+`[[rigs.overrides]]` in `city.toml` (schema documented in
+[`agent-scaling.md`](agent-scaling.md)). The warm slot eliminates the
+cold-start path: the reconciler keeps one of each template alive at all
+times, so most queued beads dispatch within seconds rather than minutes.
+
+The watchdog handles the seam where the warm slot has been killed (idle
+timeout, manual `gc session kill`, controller crash) and the reconciler
+fails to replace it. Without the warm slot, the watchdog would be the
+primary spawn engine — fine, but a 30s tick is much slower than a
+healthy reconciler.
+
+## Configuration knobs
+
+- `AGENT_WATCHDOG_RECENT_CUTOFF` (default `60`, seconds): how far back to
+  look for "the reconciler may already be spawning one." Raise it if
+  spawns routinely take longer than 60s on this host.
+
+- The template list is hard-coded to `refinery polecat`. Adding witness
+  is intentionally not done — witness has `min_active_sessions = 1` by
+  default in the gastown pack, so a missing witness already implies a
+  bigger problem the watchdog can't solve in 30s.
+
+## Operational notes
+
+- macOS bash 3.2 safe (uses tab-separated string instead of associative
+  arrays for the rig table).
+- Skips silently if `gc`, `bd`, or `jq` is missing — the cooldown order
+  doesn't need to fail loudly when its preconditions aren't met.
+- All spawn attempts log a single line to stdout:
+  `agent-watchdog: spawn <full> (queued=N, live=0)` followed by a
+  per-tick summary `agent-watchdog: spawned N session(s)` when any
+  spawn happened.
+- Failures from `gc session new` log `agent-watchdog: spawn failed for
+  <full>` but never abort the run — the next tick retries.
+
+## Disabling
+
+If the upstream supervisor bug gets fixed and the watchdog is no longer
+needed:
+
+```toml
+# city.toml
+[[orders.overrides]]
+name = "agent-watchdog"
+enabled = false
+```
+
+Or delete `packs/gascity-comms/orders/agent-watchdog.toml` and reload.
+
+## When this won't help
+
+- **Cross-host spawn.** The watchdog runs per-city; each host runs its
+  own. A queued bead in city A won't trigger a spawn on city B.
+- **Reconciler unable to spawn at all** (e.g. credential failure, host
+  out of disk). The watchdog uses the same `gc session new` path; if
+  that path is broken, the watchdog's spawn attempts also fail. Watch
+  the `agent-watchdog: spawn failed` line in the order log.
+- **Queue larger than `max_active_sessions`.** The watchdog can only
+  spawn one session per template per tick (because it gates on
+  `live == 0`). If you need more capacity, raise the agent's
+  `max_active_sessions` instead.
+
+## Related
+
+- `docs/agent-scaling.md` — schema for `[[rigs.overrides]]`, including
+  `min_active_sessions`.
+- `packs/gascity-comms/orders/agent-watchdog.toml` — the order
+  definition.
+- `packs/gascity-comms/assets/scripts/agent-watchdog.sh` — the spawn
+  loop.
+- `packs/gascity-comms/assets/scripts/gc-warm-rig-pool` — patches
+  `city.toml` to add the warm-pool overrides.

--- a/docs/diagnostic-runbook.md
+++ b/docs/diagnostic-runbook.md
@@ -99,3 +99,118 @@ so the cooldown order doesn't generate noise.
   the bead-id prefix via each rig's `.beads/metadata.json#dolt_database`.
   If a rig is missing that file, the watcher silently skips its beads.
   Rerun `bd init` in the rig if needed.
+
+## Agent spawn watchdog
+
+Backstop for the supervisor's `poolDesired → scaleCheck → session.create`
+path when it silently skips a spawn despite queued work. Pairs with
+`min_active_sessions = 1` warm slots applied via
+`packs/gascity-comms/assets/scripts/gc-warm-rig-pool`. Full architecture
+notes: [`agent-watchdog.md`](agent-watchdog.md).
+
+### Verifying the watchdog is loaded
+
+```bash
+gc config show | grep -A 3 'name = "agent-watchdog"'
+# expected: trigger = "cooldown", interval = "30s"
+```
+
+### Manual one-shot run
+
+The watchdog script is safe to invoke directly. It exits silently if
+nothing is queued.
+
+```bash
+bash packs/gascity-comms/assets/scripts/agent-watchdog.sh
+# Output (empty if all rigs have live sessions for queued work)
+```
+
+To see what it considers per template, set the recent-cutoff low so the
+race guard never fires, then watch the queued/live decision:
+
+```bash
+AGENT_WATCHDOG_RECENT_CUTOFF=0 \
+  bash -x packs/gascity-comms/assets/scripts/agent-watchdog.sh 2>&1 \
+  | grep -E '(queued|live|spawn|recent)'
+```
+
+### Test sequence: confirm spawn-on-empty-queue+0-live
+
+This proves the watchdog respawns a stalled rig within one cooldown tick
+(~30s). It is disruptive — it kills live sessions in the target rig.
+Run when the rig is otherwise idle and you can tolerate a brief gap.
+
+1. **Pick a target rig.** Use a low-traffic rig (not the one running
+   this session). Example: `synth-panel`.
+
+   ```bash
+   RIG=synth-panel
+   ```
+
+2. **Snapshot baseline.**
+
+   ```bash
+   gc session list --state=active --template "$RIG/gastown.polecat" --json | jq 'length'
+   gc session list --state=active --template "$RIG/gastown.refinery" --json | jq 'length'
+   ```
+
+3. **Queue a no-op bead for the polecat pool** (so the watchdog has a
+   reason to spawn after the kill — without queued work, the warm slot
+   itself is what gets re-spawned by the reconciler, not the watchdog):
+
+   ```bash
+   BEAD=$(bd create --title "watchdog test no-op" --type chore --priority 3 \
+     --json | jq -r '.id')
+   bd update "$BEAD" --set-metadata "gc.routed_to=$RIG/gastown.polecat" --status=open
+   ```
+
+4. **Kill all live polecat + refinery sessions in the rig.**
+
+   ```bash
+   for tpl in polecat refinery; do
+       gc session list --state=active --template "$RIG/gastown.$tpl" --json \
+         | jq -r '.[].Alias' \
+         | xargs -I{} gc session kill {} --force
+   done
+   ```
+
+5. **Wait one cooldown tick (35s) and observe the watchdog log.**
+
+   ```bash
+   sleep 35
+   gc orders log agent-watchdog --tail 20
+   # expect: "agent-watchdog: spawn $RIG/gastown.polecat (queued=1, live=0)"
+   ```
+
+6. **Confirm the session came back.**
+
+   ```bash
+   gc session list --state=active --template "$RIG/gastown.polecat" --json | jq 'length'
+   # expect: 1
+   ```
+
+7. **Clean up the no-op bead.**
+
+   ```bash
+   bd update "$BEAD" --status=closed --notes "watchdog test complete"
+   ```
+
+If step 5 shows no spawn line, common causes:
+
+| Symptom                                   | Likely cause / fix                                                    |
+|-------------------------------------------|-----------------------------------------------------------------------|
+| `recently_created>0` skip                 | Reconciler beat the watchdog. Lower `AGENT_WATCHDOG_RECENT_CUTOFF=0` and re-run. |
+| `live>0` skip                             | A reaper missed; check `gc session list --state=all` for stale beads. |
+| Order didn't fire                         | Confirm with `gc orders status agent-watchdog` and check `gc reload`. |
+| `spawn failed for $RIG/gastown.polecat`   | Run `gc session new $RIG/gastown.polecat --no-attach` manually to surface the underlying error. |
+
+### Verifying warm-pool overrides
+
+```bash
+gc config explain --agent polecat --rig <rig> | grep min_active_sessions
+# Expected after gc-warm-rig-pool: min_active_sessions = 1  # city.toml
+```
+
+If the line says `# pack` instead of `# city.toml`, the override didn't
+land — re-run `gc-warm-rig-pool --dry-run <city.toml>` to see what would
+have changed.

--- a/packs/gascity-comms/assets/scripts/agent-watchdog.sh
+++ b/packs/gascity-comms/assets/scripts/agent-watchdog.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# agent-watchdog.sh — backstop-spawn rig-scoped polecats/refineries when
+# the reconciler's auto-scale path doesn't materialize a session despite
+# queued work.
+#
+# See ../../orders/agent-watchdog.toml and ../../../../docs/agent-watchdog.md
+# for the failure modes this addresses (poolDesired flap, stale-session
+# inflation of active count) and how this script gates against double-spawn.
+#
+# Per cooldown tick:
+#   For each rig:
+#     For each scaled template (refinery, polecat):
+#       1. queued  = count of open beads waiting for this template
+#                    (pool: gc.routed_to=<full> + no assignee, plus any
+#                    open beads explicitly assigned to the template name)
+#       2. live    = count of active sessions filtered by template
+#       3. recent  = count of sessions whose CreatedAt is within the last
+#                    RECENT_CUTOFF_SECONDS (the reconciler may already be
+#                    materializing one — don't race it)
+#       4. spawn iff queued > 0 AND live == 0 AND recent == 0
+#
+# Spawning uses `gc session new <full> --no-attach` with no --alias so the
+# supervisor picks an unused name from the namepool. The script never
+# exceeds the agent's max_active_sessions because the live==0 gate means
+# we only ever add one watchdog session per tick per template; subsequent
+# ticks observe live>0 and exit early.
+#
+# Failures (gc session new exits non-zero, gc command unavailable, etc.)
+# are logged to stdout but never abort the run — the next tick retries.
+#
+# Runs as an exec order — no agent, no LLM, no wisp. macOS bash 3.2 safe.
+
+set -uo pipefail
+
+# Optional override for callers that want a different "very recent" window.
+RECENT_CUTOFF_SECONDS="${AGENT_WATCHDOG_RECENT_CUTOFF:-60}"
+
+# Templates this watchdog manages. Order is intentional: refinery first
+# because a stalled refinery blocks merge throughput across all polecats,
+# and we want to spend the spawn budget on it before scaling polecats.
+TEMPLATES="refinery polecat"
+
+if ! command -v gc >/dev/null 2>&1; then
+    exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+if ! command -v bd >/dev/null 2>&1; then
+    exit 0
+fi
+
+# -----------------------------------------------------------------------
+# Build rig table from `gc config show`. Stored as a tab-separated blob
+# (one row per rig: <name>\t<path>\n) rather than an associative array
+# so the script runs on macOS bash 3.2.
+# -----------------------------------------------------------------------
+RIG_TABLE=""
+
+config_output=$(gc config show 2>/dev/null) || exit 0
+
+current_rig=""
+in_rigs=0
+while IFS= read -r line; do
+    if [[ "$line" == "[[rigs]]" ]]; then
+        in_rigs=1
+        current_rig=""
+        continue
+    fi
+    # Any new top-level [..] header that isn't [[rigs]] or a [rigs.*]
+    # subtable closes the current rig.
+    if [[ "$line" =~ ^\[ && "$line" != "[[rigs]]" && ! "$line" =~ ^\[rigs\. ]]; then
+        in_rigs=0
+        current_rig=""
+        continue
+    fi
+    [[ "$in_rigs" -eq 1 ]] || continue
+    if [[ "$line" =~ ^name[[:space:]]*=[[:space:]]*\"(.+)\"$ && -z "$current_rig" ]]; then
+        current_rig="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^path[[:space:]]*=[[:space:]]*\"(.+)\"$ && -n "$current_rig" ]]; then
+        rig_path="${BASH_REMATCH[1]}"
+        RIG_TABLE="${RIG_TABLE}${current_rig}	${rig_path}
+"
+        current_rig=""
+    fi
+done <<< "$config_output"
+
+[[ -z "$RIG_TABLE" ]] && exit 0
+
+# -----------------------------------------------------------------------
+# Compute the "recent enough to be the reconciler's in-flight spawn" cutoff
+# in RFC3339 UTC. Try BSD date first (macOS), fall back to GNU date (Linux).
+# -----------------------------------------------------------------------
+now_epoch=$(date -u +%s)
+recent_cutoff_epoch=$((now_epoch - RECENT_CUTOFF_SECONDS))
+recent_cutoff=$(date -u -r "$recent_cutoff_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$recent_cutoff_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || echo "")
+
+# -----------------------------------------------------------------------
+# Per-rig, per-template scan.
+# -----------------------------------------------------------------------
+spawned=0
+
+while IFS=$'\t' read -r rig rig_path; do
+    [[ -z "$rig" ]] && continue
+    for template in $TEMPLATES; do
+        full_template="$rig/gastown.$template"
+
+        # Pool-routed open work, no assignee. The polecat/refinery hooks
+        # consume from this set when they wake.
+        unassigned_count=$(bd list --status=open \
+            --metadata-field "gc.routed_to=$full_template" \
+            --no-assignee --json --limit=0 2>/dev/null \
+            | jq 'length' 2>/dev/null || echo 0)
+
+        # Open beads literally assigned to the template name. Rare in
+        # practice (callers prefer routed_to + unassigned for pool work),
+        # but cover both shapes since the reconciler counts both.
+        templated_count=$(bd list --status=open \
+            --assignee "$full_template" --json --limit=0 2>/dev/null \
+            | jq 'length' 2>/dev/null || echo 0)
+
+        queued=$((unassigned_count + templated_count))
+        [[ "$queued" -le 0 ]] && continue
+
+        # Live sessions for this exact template.
+        live=$(gc session list --state active --template "$full_template" --json 2>/dev/null \
+            | jq 'length' 2>/dev/null || echo 0)
+        [[ "$live" -gt 0 ]] && continue
+
+        # Don't race the reconciler if it's already starting one for this
+        # template. The session may be visible briefly with State=active
+        # before the work is observable; this guard catches the seam.
+        if [[ -n "$recent_cutoff" ]]; then
+            recently_created=$(gc session list --state all --template "$full_template" --json 2>/dev/null \
+                | jq --arg cutoff "$recent_cutoff" '[.[] | select(.CreatedAt > $cutoff)] | length' 2>/dev/null \
+                || echo 0)
+            [[ "$recently_created" -gt 0 ]] && continue
+        fi
+
+        echo "agent-watchdog: spawn $full_template (queued=$queued, live=0)"
+        if gc session new "$full_template" --no-attach >/dev/null 2>&1; then
+            spawned=$((spawned + 1))
+        else
+            echo "agent-watchdog: spawn failed for $full_template"
+        fi
+    done
+done <<< "$RIG_TABLE"
+
+[[ "$spawned" -gt 0 ]] && echo "agent-watchdog: spawned $spawned session(s)"
+exit 0

--- a/packs/gascity-comms/assets/scripts/gc-warm-rig-pool
+++ b/packs/gascity-comms/assets/scripts/gc-warm-rig-pool
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# gc-warm-rig-pool — keep one polecat (and one refinery) warm in every
+# rig by adding `[[rigs.overrides]] min_active_sessions = 1` blocks to
+# the city.toml(s) on this host.
+#
+# Why: the reconciler's poolDesired→scaleCheck→session.create path can
+# silently skip a spawn (poolDesired flap, stale session beads in active
+# count). Warm slots eliminate the cold-start path so the agent-watchdog
+# order is a backstop rather than the primary spawn engine. See
+# docs/agent-watchdog.md for the failure modes and docs/agent-scaling.md
+# for the schema.
+#
+# Idempotency: the script parses each city.toml, walks the [[rigs]]
+# blocks, and skips any rig that already has a matching override (same
+# agent, min_active_sessions=1). New blocks are appended at the end of
+# the rig's section, before the next [[rigs]] (or first non-rig top-level
+# table). Comments and surrounding whitespace are preserved.
+#
+# Default scan: every $HOME/<town>/city.toml that exists.
+# Pass explicit city.toml paths as positional args to override discovery.
+
+set -eu
+
+usage() {
+    cat <<'EOF'
+gc-warm-rig-pool — apply min_active_sessions=1 to rig-scoped agents.
+
+Usage:
+  gc-warm-rig-pool [options] [city.toml ...]
+
+Default scan: every $HOME/<town>/city.toml that exists.
+Pass explicit city.toml paths as positional args to override discovery.
+
+Options:
+  --agents=<list>   Comma-separated agent names to override (default:
+                    polecat,refinery).
+  --dry-run         Show planned changes without writing.
+  -h, --help        Show this help.
+
+Examples:
+  gc-warm-rig-pool                              # patch every city.toml under $HOME
+  gc-warm-rig-pool --dry-run                    # preview without writing
+  gc-warm-rig-pool ~/yggdrasil/city.toml        # explicit city
+  gc-warm-rig-pool --agents=polecat ~/asgard/city.toml  # polecat only
+EOF
+}
+
+DRY_RUN=0
+AGENTS="polecat,refinery"
+TARGETS=()
+
+die() { echo "gc-warm-rig-pool: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --agents=*) AGENTS="${1#--agents=}"; shift ;;
+        --agents) shift; AGENTS="${1:?--agents requires a value}"; shift ;;
+        --) shift; while [ $# -gt 0 ]; do TARGETS+=("$1"); shift; done ;;
+        -*) die "unknown option: $1" ;;
+        *) TARGETS+=("$1"); shift ;;
+    esac
+done
+
+if [ ${#TARGETS[@]} -eq 0 ]; then
+    for d in "$HOME"/*; do
+        [ -f "$d/city.toml" ] && TARGETS+=("$d/city.toml")
+    done
+fi
+
+[ ${#TARGETS[@]} -gt 0 ] || die "no city.toml files found under $HOME/*; pass explicit paths"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    die "python3 is required (uses tomllib for parsing only; rewrite is text-based)"
+fi
+
+PATCH_SCRIPT=$(cat <<'PYEOF'
+import sys, re
+
+# Pure text parser — no tomllib dependency so this works on python <3.11
+# (tomllib lands in 3.11; tomli is the historical backport but isn't part
+# of stdlib). All we need is structural detection of [[rigs]] blocks and
+# their nested [[rigs.overrides]] sub-blocks, which is straightforward to
+# do with regexes scoped to each rig's line range.
+
+agents = [a.strip() for a in sys.argv[1].split(",") if a.strip()]
+src = sys.stdin.read()
+lines = src.split("\n")
+
+rig_header_re = re.compile(r"^\[\[rigs\]\]\s*$")
+overrides_header_re = re.compile(r"^\[\[rigs\.overrides\]\]\s*$")
+# Any other top-level [..] / [[..]] that isn't [[rigs]] or a [rigs.*]
+# sub-table closes the current rig block.
+top_other_re = re.compile(r"^\[(?:\[)?(?!rigs\b|rigs\.)[^\[\]]")
+# Nested subtables of rigs (e.g. [rigs.imports], [[rigs.overrides]]) stay
+# inside the current rig block.
+rig_subtable_re = re.compile(r"^\[(?:\[)?rigs\.")
+
+# Match a quoted string value: agent = "polecat"
+str_kv_re = re.compile(r'^([A-Za-z_][\w-]*)\s*=\s*"([^"]*)"\s*$')
+# Match an integer/bare value: min_active_sessions = 1
+num_kv_re = re.compile(r'^([A-Za-z_][\w-]*)\s*=\s*([0-9]+)\s*$')
+name_re = re.compile(r'^name\s*=\s*"([^"]*)"\s*$')
+
+# First pass: locate each [[rigs]] block as (start_line, end_line_exclusive).
+blocks = []
+i = 0
+while i < len(lines):
+    if rig_header_re.match(lines[i]):
+        start = i
+        j = i + 1
+        while j < len(lines):
+            ln = lines[j]
+            if rig_header_re.match(ln):
+                break
+            if (ln.startswith("[") and not rig_subtable_re.match(ln)
+                    and top_other_re.match(ln)):
+                break
+            j += 1
+        blocks.append({"start": start, "end": j})
+        i = j
+        continue
+    i += 1
+
+def parse_rig_block(start, end):
+    """Extract name + list of override dicts from a [[rigs]] block."""
+    name = None
+    overrides = []
+    in_override = False
+    cur = None
+    # The fields BEFORE any [rigs.*] subtable belong to the rig's top
+    # scope — that's where `name` lives.
+    in_top = True
+    for k in range(start + 1, end):
+        ln = lines[k].rstrip()
+        s = ln.lstrip()
+        if not s or s.startswith("#"):
+            continue
+        if overrides_header_re.match(s):
+            if cur is not None:
+                overrides.append(cur)
+            cur = {}
+            in_override = True
+            in_top = False
+            continue
+        if s.startswith("[") and rig_subtable_re.match(s):
+            # Some other [rigs.*] subtable (imports, etc.) — close any
+            # open override scope but keep scanning for top-level kvs.
+            if cur is not None:
+                overrides.append(cur)
+                cur = None
+            in_override = False
+            in_top = False
+            continue
+        if in_top:
+            m = name_re.match(s)
+            if m:
+                name = m.group(1)
+            continue
+        if in_override and cur is not None:
+            m = str_kv_re.match(s)
+            if m:
+                cur[m.group(1)] = m.group(2)
+                continue
+            m = num_kv_re.match(s)
+            if m:
+                cur[m.group(1)] = int(m.group(2))
+                continue
+    if cur is not None:
+        overrides.append(cur)
+    return name, overrides
+
+def has_override(overrides, agent_name):
+    # Any existing override block for this agent counts — including ones
+    # that set a different min_active_sessions value. If the operator
+    # has explicitly chosen a different value (or other fields), respect
+    # their choice instead of stacking another block.
+    for ov in overrides:
+        if ov.get("agent") == agent_name:
+            return True
+    return False
+
+changes = []  # (block_index, rig_name, [agents_to_add])
+for bi, block in enumerate(blocks):
+    rig_name, overrides = parse_rig_block(block["start"], block["end"])
+    missing = [a for a in agents if not has_override(overrides, a)]
+    if missing:
+        changes.append((bi, rig_name or f"<rig {bi}>", missing))
+
+if not changes:
+    sys.stdout.write(src)
+    sys.stderr.write("already warm: no changes\n")
+    sys.exit(0)
+
+out = list(lines)
+# Apply in reverse so earlier insertion points remain valid.
+for bi, rig_name, missing in reversed(changes):
+    block = blocks[bi]
+    insert_at = block["end"]
+    # Trim trailing blank lines inside the block so the new content
+    # appends cleanly without piling up whitespace.
+    while insert_at > block["start"] + 1 and out[insert_at - 1].strip() == "":
+        insert_at -= 1
+    snippet = []
+    for agent in missing:
+        snippet.extend([
+            "",
+            "[[rigs.overrides]]",
+            f'agent = "{agent}"',
+            "min_active_sessions = 1",
+        ])
+    out[insert_at:insert_at] = snippet
+    sys.stderr.write(
+        f"  + {rig_name}: add overrides for {', '.join(missing)}\n")
+
+sys.stdout.write("\n".join(out))
+PYEOF
+)
+
+ANY_CHANGED=0
+for target in "${TARGETS[@]}"; do
+    if [ ! -f "$target" ]; then
+        echo "skip (missing): $target"
+        continue
+    fi
+    echo "scan: $target"
+    tmp=$(mktemp)
+    if ! python3 -c "$PATCH_SCRIPT" "$AGENTS" <"$target" >"$tmp" 2>/tmp/gc-warm-rig-pool.err; then
+        cat /tmp/gc-warm-rig-pool.err >&2
+        rm -f "$tmp" /tmp/gc-warm-rig-pool.err
+        die "patch failed on $target"
+    fi
+    cat /tmp/gc-warm-rig-pool.err >&2
+    rm -f /tmp/gc-warm-rig-pool.err
+
+    if cmp -s "$target" "$tmp"; then
+        echo "  unchanged"
+        rm -f "$tmp"
+        continue
+    fi
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "  would patch (dry-run); diff:"
+        diff -u "$target" "$tmp" | sed 's/^/    /' || true
+        rm -f "$tmp"
+        continue
+    fi
+
+    cp "$target" "$target.bak.$(date -u +%Y%m%dT%H%M%SZ)" || true
+    mv "$tmp" "$target"
+    echo "  patched"
+    ANY_CHANGED=1
+done
+
+if [ "$DRY_RUN" -eq 0 ] && [ "$ANY_CHANGED" -eq 1 ]; then
+    cat <<'POSTEOF'
+
+Run `gc reload` (per city) to pick up the new min_active_sessions.
+Verify with:
+  gc config explain --agent polecat --rig <rig-name> | grep min_active_sessions
+POSTEOF
+fi

--- a/packs/gascity-comms/orders/agent-watchdog.toml
+++ b/packs/gascity-comms/orders/agent-watchdog.toml
@@ -1,0 +1,31 @@
+# agent-watchdog — backstop spawning for rig-scoped polecats and
+# refineries when the reconciler's poolDesired→scaleCheck→session.create
+# path doesn't translate the decision into an actual session.
+#
+# Background (also documented in ../../../docs/agent-watchdog.md):
+#   The supervisor logs `poolDesired: <rig>/<template> = N` correctly when
+#   work is queued, but two paths can prevent that decision from producing
+#   a spawn — (a) poolDesired flapping between consecutive ticks because
+#   the bead match window changes mid-cycle, so the higher count is never
+#   committed to a scaleCheck; (b) stale session beads (sessions whose
+#   tmux is gone but whose bead hasn't been reaped) inflate the active
+#   count, so scaleCheck thinks it has enough capacity. In both cases the
+#   reconciler silently skips the spawn and the queue stalls until a human
+#   runs `gc session new` manually.
+#
+# This order is the workaround. Each tick, for every rig in this city, it
+# checks each scaled template (refinery, polecat) and spawns a session if
+# work is queued and no live session can pick it up. min_active_sessions=1
+# (applied via packs/gascity-comms/assets/scripts/gc-warm-rig-pool) keeps
+# a warm slot so this watchdog is a backstop, not the primary scaling
+# path.
+#
+# 30s cadence: tighter than the reconciler's own pool loop, enough to
+# observe the spawn complete before the next tick. Idempotent — once a
+# session is live, subsequent ticks see live>0 and exit early.
+
+[order]
+description = "Backstop-spawn rig-scoped polecats/refineries when queued work has no live session"
+trigger = "cooldown"
+interval = "30s"
+exec = "$PACK_DIR/assets/scripts/agent-watchdog.sh"


### PR DESCRIPTION
…(dgu-uzfqj)

Workaround for the supervisor's poolDesired -> scaleCheck -> session.create path silently skipping spawns despite queued work. Two failure modes: poolDesired flap between consecutive ticks, and stale session beads inflating the active count. Both leave the queue waiting for a manual gc session new.

Three deliverables:

1. packs/gascity-comms/orders/agent-watchdog.toml + assets/scripts/ agent-watchdog.sh: 30s cooldown order. Per rig, per scaled template (refinery first, then polecat) it spawns iff queued > 0 AND live == 0 AND no session was created in the last 60s. Idempotent across ticks (live==0 gate prevents double-spawn). macOS bash 3.2 safe.

2. packs/gascity-comms/assets/scripts/gc-warm-rig-pool: text-based patcher that adds [[rigs.overrides]] agent="<name>" min_active_sessions=1 to each rig in city.toml, for polecat and refinery (configurable via --agents). Idempotent — skips rigs that already have an override for that agent. Backs up city.toml before writing. Schema documented in docs/agent-scaling.md (dgu-m72nk).

3. docs/agent-watchdog.md and a runbook section in docs/diagnostic-runbook.md covering the failure modes, the verify-load + manual-run + kill-and-respawn test sequence, and pitfalls (cross-host, broken spawn path, max_active_sessions ceiling).

Applied gc-warm-rig-pool to /Users/mani/yggdrasil/city.toml so all four rigs get warm polecat + refinery slots. asgard already had the override.