### PR TITLE
fix(gc-fix-alias-mismatch): pattern B for bare pool field in order TOMLs

### DIFF
--- a/docs/alias-canonicalization.md
+++ b/docs/alias-canonicalization.md
@@ -107,6 +107,44 @@ patterns found`. Add `--dry-run` to preview without touching files,
 `--pack=<name>` to limit the rewrite to a single pack (e.g.
 `--pack=gastown`).
 
+## Pattern B — bare `pool` field in order/formula TOMLs
+
+A second alias-mismatch surface, same class of bug, different shape.
+Order TOMLs (and the formulas that template them) carry a `pool` field
+that names the agent template the order dispatches to. The supervisor's
+dispatch query expects the FQN form (`gastown.dog`), but stock pack
+TOMLs emit the bare role name (`dog`). Result: the supervisor never
+matches a real pool, the order's session never spawns, work piles up.
+
+(Tracking: mg-ovjgn. Validation set on midgard: 16 orphan beads recovered
+manually before the fixer extension landed — mg-201z+3, mg-gjr7+3,
+mg-oc06+3, mg-wg2cp+3, all with metadata.gc.routed_to flipped from `dog`
+to `gastown.dog`.)
+
+The fixer's pattern B detection (POSIX ERE):
+
+```
+^pool[[:space:]]*=[[:space:]]*"(refinery|polecat|witness|dog)"[[:space:]]*$
+```
+
+Anchored to line start and end, so the rewrite is intentionally NARROW:
+
+- `pool = "dog"` (whole line) — rewritten to `pool = "gastown.dog"`.
+- `pool: <rig>/dog` (label form, embedded) — handled by pattern A, not B.
+- `gateway_pool = "dog"`, `polecat_namepool = "..."` — not anchored to
+  bare `pool`, so untouched.
+- `pool = "dog-quotes-with-suffix"` — value not in the role vocabulary
+  (`refinery|polecat|witness|dog`), untouched.
+
+Scope is limited to `*.toml` (the `pool` field has no meaning in `.md`).
+
+The audit script (`gc-audit-alias-mismatch`) does NOT yet flag pattern B
+findings — extension pending. For now, dry-run the fixer to see them:
+
+```bash
+gc-fix-alias-mismatch --dry-run | grep 'pattern B'
+```
+
 ## Doctor check
 
 `packs/gascity-comms/doctor/check-alias-mismatch/run.sh` wraps the audit

--- a/packs/gascity-comms/assets/scripts/gc-fix-alias-mismatch
+++ b/packs/gascity-comms/assets/scripts/gc-fix-alias-mismatch
@@ -112,32 +112,60 @@ if [ ${#PACK_FILTER[@]} -gt 0 ]; then
     [ ${#PACKS[@]} -gt 0 ] || die "no packs matched filter: ${PACK_FILTER[*]}"
 fi
 
-# Detection pattern (POSIX ERE, used with grep -E).
-PATTERN_GREP='(<rig>|\{\{ *\.RigName *\}\}|\$GC_RIG)/(refinery|polecat|witness|dog)([^A-Za-z0-9_-]|$)'
+# Two patterns are checked, with separate detection/rewrite pairs.
+#
+# (A) Templated short-form aliases — '<rig>/dog', '$GC_RIG/refinery',
+#     '{{ .RigName }}/witness', etc. Catches alias surfaces in formulas,
+#     prompts, and template fragments. (Tracking: dgu-fze, dgu-yykmt.)
+#
+# (B) Bare 'pool' field in order/formula TOMLs — 'pool = "dog"' where the
+#     supervisor's dispatch query expects 'pool = "gastown.dog"'. Same
+#     class of mismatch, different surface. (Tracking: mg-ovjgn.)
+#
+# (B) is intentionally NARROW: only matches the 'pool = "..."' line shape
+# at file start, not arbitrary 'pool' references. Keeps false-positive
+# risk minimal (gateway pool, polecat namepool, etc are unaffected).
 
-# Rewrite (Perl). Lookahead (?![\w-]) forbids alphanumerics, underscore,
+# (A) Detection pattern (POSIX ERE, used with grep -E).
+PATTERN_GREP_A='(<rig>|\{\{ *\.RigName *\}\}|\$GC_RIG)/(refinery|polecat|witness|dog)([^A-Za-z0-9_-]|$)'
+
+# (A) Rewrite (Perl). Lookahead (?![\w-]) forbids alphanumerics, underscore,
 # AND hyphen after the role base name — this is what keeps us from
 # rewriting "polecat-name" or "polecats". Rig-token group includes the
 # three template surfaces we recognize. Replacement inserts "gastown."
 # before the role base name; the lookahead is zero-width so the trailing
 # context is preserved verbatim.
-PERL_REWRITE='s{(<rig>|\{\{ *\.RigName *\}\}|\$GC_RIG)/(refinery|polecat|witness|dog)(?![\w-])}{$1/gastown.$2}g'
+PERL_REWRITE_A='s{(<rig>|\{\{ *\.RigName *\}\}|\$GC_RIG)/(refinery|polecat|witness|dog)(?![\w-])}{$1/gastown.$2}g'
 
-INCLUDES=( --include='*.toml' --include='*.md' --include='*.template.md' )
+# (B) Detection pattern: 'pool = "<role>"' as a complete TOML key=value line.
+# Anchored to line start, allowing surrounding whitespace around '='.
+PATTERN_GREP_B='^pool[[:space:]]*=[[:space:]]*"(refinery|polecat|witness|dog)"[[:space:]]*$'
+
+# (B) Rewrite: insert 'gastown.' before the role inside the quoted value.
+# Captures whitespace around '=' to preserve formatting. Anchored, so we
+# don't touch other 'pool = "..."' fields embedded in larger expressions.
+PERL_REWRITE_B='s{^(pool[ \t]*=[ \t]*)"(refinery|polecat|witness|dog)"([ \t]*)$}{$1"gastown.$2"$3}'
+
+INCLUDES_A=( --include='*.toml' --include='*.md' --include='*.template.md' )
+INCLUDES_B=( --include='*.toml' )  # pool field only meaningful in TOML
 
 files_changed=0
 files_skipped=0
 total_changes=0
 
-for pack in "${PACKS[@]}"; do
-    pack_name="$(basename "$pack")"
-    pack_changed=0
+# Process pattern A then pattern B per pack. Files matching both get
+# touched twice — that's fine, perl rewrites are idempotent and the
+# patterns don't overlap (A operates on alias surfaces, B on bare pool
+# values). Using two passes keeps the per-pattern reporting accurate.
+process_pattern() {
+    local pack="$1" pack_name="$2" label="$3" pattern="$4" rewrite="$5"
+    shift 5
+    local includes=("$@")
 
     while IFS= read -r file; do
         [ -n "$file" ] || continue
 
-        # Count matches before rewrite (one finding ≈ one substitution).
-        before=$(grep -cE "$PATTERN_GREP" "$file" 2>/dev/null || true)
+        before=$(grep -cE "$pattern" "$file" 2>/dev/null || true)
         before="${before:-0}"
 
         if [ "$before" -eq 0 ]; then
@@ -148,33 +176,38 @@ for pack in "${PACKS[@]}"; do
         rel="${file#"$pack"/}"
 
         if [ "$DRY_RUN" -eq 1 ]; then
-            printf '  would fix [%d match(es)]: %s/%s\n' "$before" "$pack_name" "$rel"
+            printf '  would fix [%d match(es), pattern %s]: %s/%s\n' \
+                "$before" "$label" "$pack_name" "$rel"
             files_changed=$((files_changed + 1))
             total_changes=$((total_changes + before))
-            pack_changed=$((pack_changed + 1))
             continue
         fi
 
         # In-place rewrite via perl. -i without a backup suffix is fine here
         # because we always git-track these files; revert is a checkout away.
-        perl -i -pe "$PERL_REWRITE" "$file"
+        perl -i -pe "$rewrite" "$file"
 
-        # Confirm the rewrite actually eliminated the patterns.
-        after=$(grep -cE "$PATTERN_GREP" "$file" 2>/dev/null || true)
+        after=$(grep -cE "$pattern" "$file" 2>/dev/null || true)
         after="${after:-0}"
         applied=$((before - after))
 
         if [ "$applied" -le 0 ]; then
-            printf '  warn: no changes applied to %s/%s (pattern matched but rewrite did nothing)\n' \
-                "$pack_name" "$rel" >&2
+            printf '  warn: no changes applied to %s/%s for pattern %s (matched but rewrite did nothing)\n' \
+                "$pack_name" "$rel" "$label" >&2
             continue
         fi
 
-        printf '  fixed [%d substitution(s)]: %s/%s\n' "$applied" "$pack_name" "$rel"
+        printf '  fixed [%d substitution(s), pattern %s]: %s/%s\n' \
+            "$applied" "$label" "$pack_name" "$rel"
         files_changed=$((files_changed + 1))
         total_changes=$((total_changes + applied))
-        pack_changed=$((pack_changed + 1))
-    done < <(grep -rlE "${INCLUDES[@]}" "$PATTERN_GREP" "$pack" 2>/dev/null || true)
+    done < <(grep -rlE "${includes[@]}" "$pattern" "$pack" 2>/dev/null || true)
+}
+
+for pack in "${PACKS[@]}"; do
+    pack_name="$(basename "$pack")"
+    process_pattern "$pack" "$pack_name" "A" "$PATTERN_GREP_A" "$PERL_REWRITE_A" "${INCLUDES_A[@]}"
+    process_pattern "$pack" "$pack_name" "B" "$PATTERN_GREP_B" "$PERL_REWRITE_B" "${INCLUDES_B[@]}"
 done
 
 echo


### PR DESCRIPTION
## Summary
Adds a second pattern to `gc-fix-alias-mismatch` covering `pool = "<role>"` lines in order/formula TOMLs. Same alias-mismatch class as the existing pattern (templated short-form aliases), different surface — supervisor's dispatch query expects FQN form `gastown.dog` but stock pack TOMLs emit bare `dog`.

Tracking: **mg-ovjgn** (midgard-side bug bead). Validation set: 16 orphan beads recovered manually on midgard before this extension landed.

## What changed
- `gc-fix-alias-mismatch` script now runs two passes per pack:
  - Pattern A (existing): templated short-form aliases (`<rig>/dog`, `$GC_RIG/refinery`, `{{ .RigName }}/witness`)
  - Pattern B (new): bare `pool = "<role>"` line in TOMLs
- `docs/alias-canonicalization.md` gains a "Pattern B" section explaining scope and the audit gap

## Verified on yggdrasil
- 7 pattern B substitutions across:
  - `gastown/orders/digest-generate.toml`
  - `gastown/formulas/mol-digest-generate.toml`
  - `dolt/orders/mol-dog-{stale-db,doctor,phantom-db,backup,compactor}.toml`
- Re-run reports `no short-form patterns found` (idempotent — marker check passes)
- Pattern A coverage unchanged: still rewrites 27 templated aliases in the same scan

## Known gap (followup)
`gc-audit-alias-mismatch` does NOT yet flag pattern B findings — the audit's `PATTERN` constant is single-pattern. Extending it requires a parallel refactor (similar shape: split into two pattern arrays, two iteration passes). Noted in docs as pending; for now, dry-run the fixer to surface findings.

## Test plan
- [x] `gc-fix-alias-mismatch --dry-run /Users/mani/yggdrasil` reports 21 files / 34 substitutions including 7 pattern-B
- [x] `gc-fix-alias-mismatch /Users/mani/yggdrasil` applies cleanly, second invocation reports `no short-form patterns found`
- [x] Manual grep confirms `pool = "gastown.dog"` everywhere `pool = "dog"` was
- [ ] Reviewer (mg-mayor) validates against the 16-bead set on midgard once mirrored