### PR TITLE
feat(gc-fix-watch): re-apply gc-fix-* helpers when pack tree changes

### DIFF
--- a/docs/pack-template-resilience.md
+++ b/docs/pack-template-resilience.md
@@ -1,0 +1,94 @@
+# Pack template resilience: gc-fix-watch
+
+The gc binary embeds pack contents (formulas, orders, prompt templates,
+etc.) at compile time and re-renders them to disk under
+`<town>/.gc/system/packs/` on supervisor startup, on some `gc supervisor
+reload` paths, and during heavy reconciler events. Any in-place patches
+applied by `gc-fix-*` helpers are wiped by the next render burst.
+
+This is wider than "survives `gc supervisor reload`" — see midgard ↔
+yggdrasil coordination thread (mg-wisp-oly, yg-wisp-t6k, ..., yg-wisp-pt7)
+for evidence on both hosts. Marker-based idempotency in helpers protects
+against double-patching but does nothing about templater wipe.
+
+## Why not patch the source
+
+The gc binary embeds packs at compile time. `strings $(which gc)` returns
+exact pack content. There is no source-on-disk to patch — `<brew>/Cellar/
+gascity/<ver>/` contains only the binary. So:
+
+- A binary fix that adds config-level pool override (e.g. `[[orders.overrides]] pool = "<fqn>"` actually being honored by the dispatch path) is the right long-term answer.
+- Until that lands, post-template fix is the only host-local option.
+
+## What gc-fix-watch does
+
+Polling daemon (no fswatch dep):
+
+1. Discovers towns: every `$HOME/<town>/.gc/system/packs/`.
+2. Hashes each town's pack tree (mtime + size + path, sorted, sha256).
+3. Every `--interval` seconds, re-hashes; if changed, debounces 2s, then
+   invokes every executable named `gc-fix-*` in `~/.gc/bin/` against the
+   town root. Helpers themselves are idempotent (marker-based) — re-fires
+   on unchanged trees report "already fixed" and exit cheaply.
+4. Updates the baseline post-helpers (helpers may rewrite files).
+
+Pack-agnostic: any future helper participates by symlinking into
+`~/.gc/bin/gc-fix-<name>`. No edits to gc-fix-watch required.
+
+## Installing
+
+```bash
+ln -sf ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-fix-watch \
+    ~/.gc/bin/gc-fix-watch
+```
+
+Foreground for testing:
+
+```bash
+gc-fix-watch --interval 30
+```
+
+Background (macOS):
+
+```bash
+sed "s|{{HOME}}|$HOME|g" \
+    ~/dv-gascity-utils/packs/gascity-comms/assets/launchd/com.dv-gascity.fix-watch.plist.template \
+    > ~/Library/LaunchAgents/com.dv-gascity.fix-watch.plist
+launchctl load ~/Library/LaunchAgents/com.dv-gascity.fix-watch.plist
+tail -f ~/Library/Logs/gc-fix-watch.log
+```
+
+Background (Linux):
+
+```bash
+cp ~/dv-gascity-utils/packs/gascity-comms/assets/systemd/gc-fix-watch.service.template \
+    ~/.config/systemd/user/gc-fix-watch.service
+systemctl --user daemon-reload
+systemctl --user enable --now gc-fix-watch.service
+journalctl --user -u gc-fix-watch -f
+```
+
+## Operating notes
+
+- **Initial helper run.** gc-fix-watch only re-applies on detected change.
+  If the gc binary re-templates the pack tree before the watcher starts,
+  the watcher takes a baseline of the wiped state and never re-applies.
+  Run helpers manually once before activating the watcher (or include a
+  startup-run wrapper if you prefer).
+- **Cadence.** 30s default is well under the time it takes for
+  re-templated work to propagate to running sessions. Tighten with
+  `--interval` if you observe missed cycles.
+- **Helper failures don't kill the watcher.** A non-zero exit from any
+  fix-* helper is logged and ignored; subsequent helpers in the same
+  cycle still run.
+- **Excludes self.** gc-fix-watch matches its own name pattern but is
+  filtered out at dispatch — no infinite recursion when symlinked
+  alongside the other helpers.
+
+## Tracking
+
+- mg-side: see mg-ovjgn (pool FQN mismatch root cause) and the coordination
+  thread starting at mg-wisp-oly.
+- The "real fix" is binary-side: orders.overrides should accept and honor
+  a `pool` field, and the templater should not silently overwrite files
+  that already match the desired output. Both filed as upstream bugs.

--- a/packs/gascity-comms/assets/launchd/com.dv-gascity.fix-watch.plist.template
+++ b/packs/gascity-comms/assets/launchd/com.dv-gascity.fix-watch.plist.template
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd template for gc-fix-watch (macOS).
+
+  Install:
+    1. Replace {{HOME}} with your absolute home path (e.g. /Users/openclaw).
+    2. Copy to ~/Library/LaunchAgents/com.dv-gascity.fix-watch.plist
+    3. launchctl load ~/Library/LaunchAgents/com.dv-gascity.fix-watch.plist
+    4. tail -f ~/Library/Logs/gc-fix-watch.log
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.dv-gascity.fix-watch.plist
+    rm ~/Library/LaunchAgents/com.dv-gascity.fix-watch.plist
+
+  This is a LaunchAgent (per-user), not a LaunchDaemon (system-wide). It
+  runs as the logged-in user and dies on logout. That matches how the
+  gc supervisor itself runs: there's no point auto-fixing pack files for
+  a supervisor that isn't running.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.dv-gascity.fix-watch</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{HOME}}/.gc/bin/gc-fix-watch</string>
+        <string>--interval</string>
+        <string>30</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/Library/Logs/gc-fix-watch.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/Library/Logs/gc-fix-watch.log</string>
+
+    <key>WorkingDirectory</key>
+    <string>{{HOME}}</string>
+
+    <!-- Throttle: launchd otherwise restarts a crashing job every 1s. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/packs/gascity-comms/assets/scripts/gc-fix-watch
+++ b/packs/gascity-comms/assets/scripts/gc-fix-watch
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# gc-fix-watch — re-apply gc-fix-* helpers after the gc binary re-templates packs.
+#
+# Why this exists:
+#
+# The gc binary embeds pack contents (formulas, orders, prompt templates,
+# etc.) at compile time and re-renders them to disk under
+# `<town>/.gc/system/packs/` on supervisor startup, on some `gc supervisor
+# reload` paths, and during heavy reconciler events. Any in-place patches
+# applied by gc-fix-* helpers are wiped by the next render burst, even
+# though the helpers themselves are idempotent and safe to re-run.
+#
+# Per-host workaround until the binary supports config-level overrides
+# (e.g. `[[orders.overrides]] pool = "<fqn>"` actually being honored, or
+# a `[[agent]] override` table that survives re-template):
+# watch the pack tree, and re-run every gc-fix-* helper symlinked into
+# `~/.gc/bin/` whenever the tree changes. Helpers are idempotent (each
+# uses a marker check), so re-firing on every render burst is safe.
+#
+# Pack-agnostic: invokes every executable named `gc-fix-*` in `~/.gc/bin/`
+# (resolving symlinks). New helpers register by symlinking — no edits
+# here required.
+#
+# Activation: foreground daemon by default. Background via launchd plist
+# on macOS or systemd unit on Linux (templates under packs/gascity-comms/
+# assets/launchd/ and assets/systemd/).
+#
+# Tracking: gc-binary re-template wipe (mg-ovjgn discussion, dgu-side TBD).
+
+set -euo pipefail
+
+# --- Defaults -----------------------------------------------------------
+
+INTERVAL=30        # poll seconds; debounced 2s after change detected
+DRY_RUN=0
+ONCE=0
+QUIET=0
+ROOTS=()
+
+# --- Helpers ------------------------------------------------------------
+
+die() { echo "gc-fix-watch: $*" >&2; exit 1; }
+
+log() {
+    [ "$QUIET" -eq 1 ] && return 0
+    echo "[$(date -u +%FT%TZ)] $*"
+}
+
+usage() {
+    cat <<'EOF'
+gc-fix-watch — re-apply gc-fix-* helpers when the pack tree changes.
+
+Usage:
+  gc-fix-watch [options] [town-root ...]
+
+Default scan: every $HOME/<town>/.gc/system/packs/ that exists.
+Pass explicit town-root paths as positional args to override discovery.
+
+Options:
+  --interval N    Poll interval in seconds (default 30).
+  --once          Run a single check and exit (for testing).
+  --dry-run       Detect change; print helpers that would run; don't run them.
+  --quiet         Suppress periodic status output.
+  -h, --help      Show this help.
+
+Examples:
+  gc-fix-watch                            # foreground daemon, default cadence
+  gc-fix-watch --once --dry-run           # one-shot preview
+  gc-fix-watch --interval 10 ~/midgard    # tight polling on a specific town
+EOF
+}
+
+# --- Argument parsing ---------------------------------------------------
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --once) ONCE=1; shift ;;
+        --quiet) QUIET=1; shift ;;
+        --interval)
+            shift
+            [ $# -gt 0 ] || die "--interval requires a value"
+            INTERVAL="$1"
+            shift
+            ;;
+        --) shift; while [ $# -gt 0 ]; do ROOTS+=("$1"); shift; done ;;
+        -*) die "unknown option: $1" ;;
+        *) ROOTS+=("$1"); shift ;;
+    esac
+done
+
+# --- Discovery ----------------------------------------------------------
+
+if [ ${#ROOTS[@]} -eq 0 ]; then
+    for d in "$HOME"/*; do
+        [ -d "$d/.gc/system/packs" ] && ROOTS+=("$d")
+    done
+fi
+
+[ ${#ROOTS[@]} -gt 0 ] || die "no towns found under $HOME/* with .gc/system/packs/; pass explicit roots"
+
+# Validate roots up front so a typo doesn't fail silently mid-loop.
+for r in "${ROOTS[@]}"; do
+    [ -d "$r/.gc/system/packs" ] || die "not a town root (no .gc/system/packs/): $r"
+done
+
+# --- Helper discovery ---------------------------------------------------
+
+# discover_helpers — lists executable gc-fix-* helpers in ~/.gc/bin/, one
+# per line, EXCLUDING gc-fix-watch itself (no infinite recursion when
+# watcher gets symlinked alongside the helpers).
+discover_helpers() {
+    local self
+    self="$(basename "${BASH_SOURCE[0]}")"
+    local bin_dir="$HOME/.gc/bin"
+    [ -d "$bin_dir" ] || return 0
+
+    # Use a glob that survives no-match (nullglob). Restore default after.
+    shopt -s nullglob
+    for f in "$bin_dir"/gc-fix-*; do
+        local name
+        name="$(basename "$f")"
+        [ "$name" = "$self" ] && continue
+        [ -x "$f" ] || continue
+        echo "$f"
+    done
+    shopt -u nullglob
+}
+
+# --- Mtree hashing ------------------------------------------------------
+
+# mtree_hash — content+timestamp fingerprint of a town's pack tree.
+# Uses stat -f for macOS portability; falls back to GNU stat on Linux.
+# Each line: <mtime> <size> <relative-path>. Sorted, then SHA-256.
+mtree_hash() {
+    local town="$1"
+    local pack_root="$town/.gc/system/packs"
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        # macOS stat (BSD): -f format string, %m=mtime epoch, %z=size, %N=name.
+        find "$pack_root" -type f -print0 2>/dev/null \
+            | xargs -0 stat -f '%m %z %N' 2>/dev/null \
+            | sort
+    else
+        # Linux stat (GNU): -c format string, %Y=mtime epoch, %s=size, %n=name.
+        find "$pack_root" -type f -print0 2>/dev/null \
+            | xargs -0 stat -c '%Y %s %n' 2>/dev/null \
+            | sort
+    fi | shasum -a 256 | awk '{print $1}'
+}
+
+# --- Helper dispatch ----------------------------------------------------
+
+# run_helpers — invokes every discovered gc-fix-* helper against one town.
+# Each helper writes its own "fixed" / "already fixed" output. We capture
+# stdout+stderr line-by-line and prefix for readability.
+run_helpers() {
+    local town="$1"
+    local count=0
+    local helper
+
+    while IFS= read -r helper; do
+        count=$((count + 1))
+        if [ "$DRY_RUN" -eq 1 ]; then
+            log "  would run: $(basename "$helper") $town"
+        else
+            log "  running: $(basename "$helper")"
+            # Run helper; indent its output. Don't fail the watcher if a
+            # helper errors — log and continue.
+            if ! "$helper" "$town" 2>&1 | sed 's|^|    |'; then
+                log "  warn: $(basename "$helper") exited non-zero (continuing)"
+            fi
+        fi
+    done < <(discover_helpers)
+
+    [ "$count" -eq 0 ] && log "  warn: no gc-fix-* helpers found in ~/.gc/bin/ (nothing to run)"
+}
+
+# --- Main loop ----------------------------------------------------------
+
+# Parallel arrays for baselines (bash 3.2 on macOS lacks `declare -A`).
+# BASELINES[i] is the most recent mtree hash for ROOTS[i].
+BASELINES=()
+
+log "starting (towns: ${ROOTS[*]}, interval: ${INTERVAL}s, dry-run: ${DRY_RUN}, once: ${ONCE})"
+
+# Initial baseline. Don't run helpers on startup — we trust prior state.
+# (Operators should run helpers manually once before activating watcher;
+# subsequent re-templates will be caught.)
+for i in "${!ROOTS[@]}"; do
+    BASELINES[$i]="$(mtree_hash "${ROOTS[$i]}")"
+    log "baseline: ${ROOTS[$i]} -> ${BASELINES[$i]:0:12}"
+done
+
+if [ "$ONCE" -eq 1 ]; then
+    log "--once: skipping watch loop"
+    exit 0
+fi
+
+while true; do
+    sleep "$INTERVAL"
+    for i in "${!ROOTS[@]}"; do
+        town="${ROOTS[$i]}"
+        new="$(mtree_hash "$town")"
+        if [ "$new" != "${BASELINES[$i]}" ]; then
+            log "change detected: $town (${BASELINES[$i]:0:12} -> ${new:0:12})"
+            # Debounce: re-template can write files in bursts. Wait 2s
+            # and re-hash; if still changing, the write is in progress
+            # — wait one more cycle.
+            sleep 2
+            settled="$(mtree_hash "$town")"
+            if [ "$settled" != "$new" ]; then
+                log "  still changing; deferring to next cycle"
+                BASELINES[$i]="$settled"
+                continue
+            fi
+            run_helpers "$town"
+            # Update baseline AFTER helpers (they themselves may rewrite files).
+            BASELINES[$i]="$(mtree_hash "$town")"
+            log "  baseline updated: ${BASELINES[$i]:0:12}"
+        fi
+    done
+done

--- a/packs/gascity-comms/assets/systemd/gc-fix-watch.service.template
+++ b/packs/gascity-comms/assets/systemd/gc-fix-watch.service.template
@@ -1,0 +1,37 @@
+# systemd user unit template for gc-fix-watch (Linux).
+#
+# Install (per-user, runs while logged in):
+#   1. Copy to ~/.config/systemd/user/gc-fix-watch.service
+#   2. systemctl --user daemon-reload
+#   3. systemctl --user enable --now gc-fix-watch.service
+#   4. journalctl --user -u gc-fix-watch -f
+#
+# Uninstall:
+#   systemctl --user disable --now gc-fix-watch.service
+#   rm ~/.config/systemd/user/gc-fix-watch.service
+#   systemctl --user daemon-reload
+#
+# Lingering (run even when user not logged in):
+#   sudo loginctl enable-linger $USER
+#
+# Per-user matches macOS LaunchAgent semantics: the gc supervisor runs as
+# the user, so the watcher should too. If your supervisor is a system
+# service, install this as a system unit (/etc/systemd/system/) instead
+# and adjust User=/Group=.
+
+[Unit]
+Description=gc-fix-watch — re-apply gc-fix-* helpers when pack tree changes
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=%h/.gc/bin/gc-fix-watch --interval 30
+Restart=on-failure
+RestartSec=10s
+
+# Don't tie watcher lifetime to a TTY; allow detached operation.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Adds `gc-fix-watch`: a polling daemon that re-runs every `gc-fix-*` helper symlinked into `~/.gc/bin/` whenever a town's pack tree changes on disk. Solves the templater-wipe problem: the gc binary re-renders embedded pack contents on supervisor startup / reload / heavy reconciler events, wiping in-place patches our fix helpers apply.

Per-host workaround until config-level overrides land binary-side. Pack source is binary-embedded (`strings $(which gc)` returns formula contents) so there's no source-on-disk to patch — post-template re-application is the only option.

Tracking: **mg-ovjgn** (pool FQN mismatch root cause). Coordination thread starts at mg-wisp-oly through yg-wisp-pt7.

## What changed

- `packs/gascity-comms/assets/scripts/gc-fix-watch` — main daemon
- `packs/gascity-comms/assets/launchd/com.dv-gascity.fix-watch.plist.template` — macOS LaunchAgent
- `packs/gascity-comms/assets/systemd/gc-fix-watch.service.template` — Linux systemd user unit
- `docs/pack-template-resilience.md` — design + install instructions

## Design choices

- **Pack-agnostic.** Discovers helpers via glob `~/.gc/bin/gc-fix-*` (resolves symlinks, excludes self). Future helpers participate by symlinking; no edits to gc-fix-watch.
- **Polling, not fswatch.** No external dep (fswatch isn't on either of our hosts by default). 30s default poll is well under the time it takes for re-templated work to propagate to running sessions.
- **Debounced.** 2s hold-off after first detected change; if still settling, defer to next cycle. Avoids running helpers mid-render.
- **bash 3.2 compatible.** Parallel arrays instead of `declare -A` (macOS default bash).
- **Idempotent re-fires safe.** Helpers themselves use marker checks; re-runs report "already fixed" cheaply.
- **No initial helper run.** Watcher only re-applies on detected change. Operators run helpers manually once before activation; subsequent re-templates caught. Documented in operating notes.

## Verified on midgard

- `--once --dry-run`: discovery + baseline correct.
- Live test: with patches applied, manually reverted `pool = "gastown.dog"` → `pool = "dog"` in `dolt/orders/mol-dog-stale-db.toml`. Watcher detected change within 5s (interval=5), debounced 2s, invoked `gc-fix-alias-mismatch` + `gc-fix-merge-strategy`. Pattern B re-applied; file restored to `pool = "gastown.dog"`.
- Excludes self correctly (no recursion when symlinked alongside other helpers).

## Test plan

- [ ] Reviewer (yg-mayor) mirrors to yggdrasil host: clone, symlink, run mutation test
- [ ] Verify both LaunchAgent and systemd templates load cleanly with appropriate substitutions
- [ ] Run for 24h on at least one host to confirm no unexpected wakes / resource impact

## Open questions

- Should the watcher do an initial helper run at startup, not just take a baseline? Argument for: covers the case where gc binary re-templates before watcher starts. Argument against: redundant for fresh installs where helpers were just run manually. Currently doesn't; documented.
- Cadence default: 30s feels right for our usage. Lower if either host observes missed cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)