### PR TITLE
fix(gc-audit-alias-mismatch): pattern B coverage matches the fixer

### DIFF
--- a/docs/alias-canonicalization.md
+++ b/docs/alias-canonicalization.md
@@ -138,12 +138,18 @@ Anchored to line start and end, so the rewrite is intentionally NARROW:
 
 Scope is limited to `*.toml` (the `pool` field has no meaning in `.md`).
 
-The audit script (`gc-audit-alias-mismatch`) does NOT yet flag pattern B
-findings — extension pending. For now, dry-run the fixer to see them:
+Both `gc-audit-alias-mismatch` (read-only) and `gc-fix-alias-mismatch`
+(rewrite) flag pattern B findings. Audit output tags each finding with
+its pattern label:
 
-```bash
-gc-fix-alias-mismatch --dry-run | grep 'pattern B'
 ```
+dolt/orders/mol-dog-doctor.toml:6 [pattern B]
+  -- pool = "dog"
+  ++ pool = "gastown.dog"
+```
+
+JSON mode (`--json`) emits a `"pattern":"A"` or `"pattern":"B"` field
+per finding for downstream tooling.
 
 ## Doctor check
 

--- a/packs/gascity-comms/assets/scripts/gc-audit-alias-mismatch
+++ b/packs/gascity-comms/assets/scripts/gc-audit-alias-mismatch
@@ -123,10 +123,27 @@ expand_roots "${ROOTS[@]}"
 #
 # Already-canonical forms <rig>/gastown.refinery don't match because the
 # slash-separated segment after / starts with "gastown." not the bare role.
-PATTERN='(<rig>|\{\{ *\.RigName *\}\}|\$GC_RIG)/(refinery|polecat|witness|dog)([^A-Za-z0-9_-]|$)'
+# Two patterns are flagged separately so report output stays diagnosable.
+#
+# (A) Templated short-form aliases — '<rig>/dog', '$GC_RIG/refinery',
+#     '{{ .RigName }}/witness'. Matches in formulas, prompts, and template
+#     fragments. Fixer rewrites by inserting 'gastown.' before the role.
+#
+# (B) Bare 'pool' field in order/formula TOMLs — 'pool = "dog"' where
+#     supervisor's dispatch query expects 'pool = "gastown.dog"'. Same
+#     class of mismatch, different surface. (Tracking: mg-ovjgn.)
+#
+# Pattern B is intentionally NARROW: anchored start-and-end, only the
+# bare 'pool = "..."' shape, only on .toml. Doesn't touch 'pool: <rig>/dog'
+# (handled by A), gateway_pool, polecat_namepool, or other 'pool' refs.
 
-# Scope filter: include only files that can plausibly carry alias references.
-INCLUDES=( --include='*.toml' --include='*.md' --include='*.template.md' )
+PATTERN_A='(<rig>|\{\{ *\.RigName *\}\}|\$GC_RIG)/(refinery|polecat|witness|dog)([^A-Za-z0-9_-]|$)'
+PATTERN_B='^pool[[:space:]]*=[[:space:]]*"(refinery|polecat|witness|dog)"[[:space:]]*$'
+
+# Scope filters per pattern. (A) covers alias references generally;
+# (B) is .toml-only because the 'pool' field has no meaning elsewhere.
+INCLUDES_A=( --include='*.toml' --include='*.md' --include='*.template.md' )
+INCLUDES_B=( --include='*.toml' )
 
 found_total=0
 
@@ -135,42 +152,61 @@ found_total=0
 PACK_NAMES=()
 PACK_COUNTS=()
 
+# emit_finding — formats one finding (JSON or human-readable) and updates
+# the running totals. Used by both pattern passes.
+emit_finding() {
+    local pack_name="$1" rel="$2" lineno="$3" alias_span="$4" suggested="$5" pattern_label="$6"
+
+    if [ "$JSON" -eq 1 ]; then
+        # Hand-rolled JSON: pack/file paths are ASCII; no escaping needed
+        # for the role + token vocabulary we control.
+        printf '{"pack":"%s","file":"%s","line":%s,"match":"%s","suggested":"%s","pattern":"%s"}\n' \
+            "$pack_name" "$rel" "$lineno" "$alias_span" "$suggested" "$pattern_label"
+    elif [ "$QUIET" -eq 0 ]; then
+        printf '  %s/%s:%s [pattern %s]\n' "$pack_name" "$rel" "$lineno" "$pattern_label"
+        printf '    -- %s\n' "$alias_span"
+        printf '    ++ %s\n' "$suggested"
+    fi
+}
+
 for pack in "${PACKS[@]}"; do
     pack_name="$(basename "$pack")"
     pack_count=0
 
-    # grep -n -E -H over the pack tree; tolerate empty/missing dirs.
+    # ----- Pattern A: templated short-form aliases -----
     while IFS= read -r line; do
-        # grep output: <file>:<line-no>:<matched-line-text>
         file="${line%%:*}"; rest="${line#*:}"
         lineno="${rest%%:*}"; matched="${rest#*:}"
 
-        # Extract only the matched span for the suggested-fix output. We
-        # know there is exactly one short-form per matched line in practice;
-        # if multiple exist we still suggest the first one (rare; the fixer
-        # rewrites all occurrences via sed regardless).
-        match=$(printf '%s\n' "$matched" | grep -oE "$PATTERN" | head -n1 || true)
-        # Strip any trailing context char from the match (we only want the
-        # alias span, not the boundary char that anchored the match).
+        # Extract the matched alias span (one per line in practice).
+        match=$(printf '%s\n' "$matched" | grep -oE "$PATTERN_A" | head -n1 || true)
+        # Strip trailing boundary char; we only want the alias text.
         alias_span=$(printf '%s' "$match" | sed -E 's/[^A-Za-z0-9_$}>-]$//')
         suggested=$(printf '%s' "$alias_span" | sed -E 's~/(refinery|polecat|witness|dog)$~/gastown.\1~')
 
         rel="${file#"$pack"/}"
-
-        if [ "$JSON" -eq 1 ]; then
-            # Hand-rolled JSON: pack/file paths are ASCII; no escaping needed
-            # for the role + token vocabulary we control.
-            printf '{"pack":"%s","file":"%s","line":%s,"match":"%s","suggested":"%s"}\n' \
-                "$pack_name" "$rel" "$lineno" "$alias_span" "$suggested"
-        elif [ "$QUIET" -eq 0 ]; then
-            printf '  %s/%s:%s\n' "$pack_name" "$rel" "$lineno"
-            printf '    -- %s\n' "$alias_span"
-            printf '    ++ %s\n' "$suggested"
-        fi
+        emit_finding "$pack_name" "$rel" "$lineno" "$alias_span" "$suggested" "A"
 
         found_total=$((found_total + 1))
         pack_count=$((pack_count + 1))
-    done < <(grep -rn -E "${INCLUDES[@]}" "$PATTERN" "$pack" 2>/dev/null || true)
+    done < <(grep -rn -E "${INCLUDES_A[@]}" "$PATTERN_A" "$pack" 2>/dev/null || true)
+
+    # ----- Pattern B: bare 'pool = "<role>"' lines -----
+    while IFS= read -r line; do
+        file="${line%%:*}"; rest="${line#*:}"
+        lineno="${rest%%:*}"; matched="${rest#*:}"
+
+        # The matched line IS the alias span — strip surrounding whitespace.
+        alias_span=$(printf '%s' "$matched" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
+        # Suggested rewrite: insert 'gastown.' before the role inside quotes.
+        suggested=$(printf '%s' "$alias_span" | sed -E 's/"(refinery|polecat|witness|dog)"/"gastown.\1"/')
+
+        rel="${file#"$pack"/}"
+        emit_finding "$pack_name" "$rel" "$lineno" "$alias_span" "$suggested" "B"
+
+        found_total=$((found_total + 1))
+        pack_count=$((pack_count + 1))
+    done < <(grep -rn -E "${INCLUDES_B[@]}" "$PATTERN_B" "$pack" 2>/dev/null || true)
 
     PACK_NAMES+=("$pack_name")
     PACK_COUNTS+=("$pack_count")


### PR DESCRIPTION
## Summary
Closes the asymmetry where `gc-fix-alias-mismatch` rewrites bare `pool = \"<role>\"` lines (pattern B, added in PR #4) but `gc-audit-alias-mismatch` didn't flag them. After this, both audit and fixer have matching coverage.

Tracking: mg-ovjgn (pool FQN mismatch root cause).

## What changed
- `gc-audit-alias-mismatch` now runs both pattern A (templated short-form aliases) and pattern B (bare pool field) passes per pack
- Output tags each finding with its pattern label (`[pattern A]` / `[pattern B]`)
- JSON mode adds a `\"pattern\":\"A\"|\"B\"` field
- `docs/alias-canonicalization.md` updated to remove the \"audit gap\" caveat

## Verified on yggdrasil
```
$ gc-audit-alias-mismatch --no-fail /Users/mani/yggdrasil
gc-audit-alias-mismatch: 5 pack(s) scanned, no short-form findings.

# manually reverted pool = \"gastown.dog\" → pool = \"dog\" in mol-dog-doctor.toml

$ gc-audit-alias-mismatch --no-fail /Users/mani/yggdrasil
  dolt/orders/mol-dog-doctor.toml:6 [pattern B]
    -- pool = \"dog\"
    ++ pool = \"gastown.dog\"

gc-audit-alias-mismatch: 1 finding(s) across 5 pack(s):
  dolt: 1

# re-ran fixer, audit clean again
```

## Test plan
- [x] yg: clean baseline → 0 findings
- [x] yg: mutated → 1 pattern-B finding with correct line + suggestion
- [x] yg: post-fix → 0 findings (audit + fixer agreement)
- [ ] mg-mayor mirrors and confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)