### PR TITLE
feat: gc-city-bootstrap script + new-city-bootstrap doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ DataViking-Tech utilities and patterns for [Gas City](https://docs.gascityhall.c
 
 ### Docs
 
+- **`docs/new-city-bootstrap.md`** — start here when scaffolding a new host. Walks the `gc-city-bootstrap` script + the manual follow-up checklist (city init, peers.toml, token distribution, polecat scaling, verification).
 - **`docs/multi-city-shared-dolt.md`** — running multiple cities (each with its own gc supervisor) against a single shared Dolt server, including how rigs partition into separate databases by prefix and how cross-city mail flows between them.
 - **`docs/cross-city-comms.md`** — the architecture: per-host Caddy gateway on the Tailscale interface, bearer auth, `peers.toml` registry, the `gcx` wrapper, the in-band `X-Gascity-Origin` header convention for reply routing, and the per-city `mail-nudge` order for autonomous wake-on-arrival.
 - **`docs/cross-city-mail-protocol.md`** — payload-level contract for cross-city wisps: why `X-Gascity-Origin` lives in body line 1 (canonical) vs. the HTTP header (forward-compat only, currently dropped by both gateway receive paths), how `gcx mail reply` parses it, and the sender contract for raw-curl callers.
@@ -25,9 +26,37 @@ DataViking-Tech utilities and patterns for [Gas City](https://docs.gascityhall.c
 
 Pre-alpha. Built during initial multi-city setup of `yggdrasil` (HQ on `mani-mac-mini`), `midgard` (`sol-mac-mini`), and `asgard` (external-agent home, also on mani-mac-mini). Patterns and pack contents are evolving as the architecture firms up.
 
-## Importing the pack
+## Bootstrapping a new host
 
-Until `gc pack add <git-url>` is wired up here, the bootstrap is manual:
+The fast path is `gc-city-bootstrap`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DataViking-Tech/dv-gascity-utils/main/packs/gascity-comms/assets/scripts/gc-city-bootstrap \
+    -o /tmp/gc-city-bootstrap
+chmod +x /tmp/gc-city-bootstrap
+/tmp/gc-city-bootstrap --dry-run    # preview
+/tmp/gc-city-bootstrap              # apply
+```
+
+The script clones dv-gascity-utils, symlinks the helpers into
+`~/.gc/bin/`, generates a gateway token, drops a Caddyfile + LaunchAgents,
+and runs the `gc-fix-*` helpers once against any installed city packs.
+It's idempotent — re-running on a partially-set-up host is safe.
+
+What stays manual (operator decisions the script can't make for you):
+
+- `gc init <city-name>` and `gc rig add` for each project
+- Editing `~/.gc/peers.toml` from the template + distributing your
+  gateway token to peer hosts via secure channel
+- Polecat warm-pool overrides in `city.toml` (per-rig decision; see
+  `docs/agent-scaling.md`)
+
+End-to-end recipe with the manual checklist: **`docs/new-city-bootstrap.md`**.
+
+## Importing the pack manually
+
+If you need to apply the gascity-comms pack to a city without running
+the bootstrap script:
 
 ```bash
 git clone https://github.com/DataViking-Tech/dv-gascity-utils ~/dv-gascity-utils
@@ -37,18 +66,14 @@ git clone https://github.com/DataViking-Tech/dv-gascity-utils ~/dv-gascity-utils
 gc reload
 ```
 
-Then per-host:
+Per-host symlinks the bootstrap script handles automatically:
 
 ```bash
-ln -sf ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gcx ~/.gc/bin/gcx
-ln -sf ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-rig-join ~/.gc/bin/gc-rig-join
-ln -sf ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-audit-alias-mismatch ~/.gc/bin/gc-audit-alias-mismatch
-ln -sf ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-fix-alias-mismatch ~/.gc/bin/gc-fix-alias-mismatch
-# gc-fix-refinery-routing is now a deprecation shim that forwards to
-# gc-fix-alias-mismatch — keep it symlinked only if you have existing
-# scripts or muscle memory that calls it by its old name:
-ln -sf ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-fix-refinery-routing ~/.gc/bin/gc-fix-refinery-routing
-ln -sf ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-fix-merge-strategy ~/.gc/bin/gc-fix-merge-strategy
+for h in gcx gc-rig-join gc-audit-alias-mismatch gc-fix-alias-mismatch \
+         gc-fix-refinery-routing gc-fix-merge-strategy gc-fix-watch \
+         gc-warm-rig-pool gc-tune-refinery-loop gc-city-bootstrap; do
+    ln -sf "$HOME/dv-gascity-utils/packs/gascity-comms/assets/scripts/$h" "$HOME/.gc/bin/$h"
+done
 cp ~/dv-gascity-utils/packs/gascity-comms/assets/templates/peers.toml.template ~/.gc/peers.toml
 # fill in url + token_file for each peer
 ```

--- a/docs/new-city-bootstrap.md
+++ b/docs/new-city-bootstrap.md
@@ -1,0 +1,233 @@
+# Bootstrapping a new Gas City
+
+End-to-end recipe for bringing a new host into a multi-city Gas City
+deployment. The mechanical steps are wrapped in `gc-city-bootstrap`;
+this doc walks the manual decisions around it.
+
+If you're scaffolding a fresh city in a new repo, run the script first,
+then come back here for the manual checklist.
+
+## What you need before starting
+
+- macOS or Linux host with `git`, `bash` (3.2+), `openssl`, `caddy`
+  (any 2.x), `gh` (GitHub CLI), and `gc` (homebrew-installed Gas City
+  binary).
+- Tailscale running on this host. The gateway binds the host's
+  Tailscale IP for cross-city RPC.
+- SSH or other secure channel to peer hosts you want to talk to. Tokens
+  must travel out-of-band.
+- A name for this city (`gc init <name>` later — pick a stable one;
+  it's the city slug other hosts use to address you).
+
+## TL;DR
+
+```bash
+# 1. Run the bootstrap script. It clones dv-gascity-utils, symlinks
+#    helpers, generates a gateway token, drops Caddyfile + LaunchAgents,
+#    and runs the fix-* helpers once against any city packs already
+#    installed.
+curl -fsSL https://raw.githubusercontent.com/DataViking-Tech/dv-gascity-utils/main/packs/gascity-comms/assets/scripts/gc-city-bootstrap \
+    -o /tmp/gc-city-bootstrap
+chmod +x /tmp/gc-city-bootstrap
+/tmp/gc-city-bootstrap --dry-run    # preview
+/tmp/gc-city-bootstrap              # apply
+
+# 2. Initialize the city (or skip if you already have one).
+gc init my-new-city
+
+# 3. Edit ~/.gc/peers.toml from the template (manual; see below).
+
+# 4. Distribute ~/.gc/tokens/<this-host>-gateway.token to peer hosts
+#    via secure channel.
+
+# 5. Apply polecat scaling overrides in city.toml (manual; depends on
+#    rig profile).
+```
+
+After step 1 you have a working host with helpers + watcher + gateway
+ready to go. Steps 2-5 are operator decisions the script can't make for
+you.
+
+## What gc-city-bootstrap does
+
+The script is in `packs/gascity-comms/assets/scripts/gc-city-bootstrap`
+and is idempotent — re-running on a partially-configured host is safe.
+
+| Step | Action | Notes |
+|------|--------|-------|
+| 1 | Clone or fast-forward `~/dv-gascity-utils` | Skipped if already cloned and clean. |
+| 2 | Symlink `gcx`, `gc-fix-*`, `gc-rig-join`, etc into `~/.gc/bin/` | Idempotent. |
+| 3 | Generate `~/.gc/tokens/<host>-gateway.token` if missing | 32 bytes hex via `openssl rand`. Mode 0600. |
+| 4 | Render `~/.gc/gateway/Caddyfile` with this host's Tailscale IP | Auto-detects via `tailscale ip -4`; fallback `--ts-ip`. |
+| 5 | Render LaunchAgent plists for fix-watch + gateway | macOS only; Linux uses systemd templates from `pack-template-resilience.md`. |
+| 6 | Load both LaunchAgents | `bootout` + `bootstrap`, idempotent. |
+| 7 | Run each `gc-fix-*` helper once per discovered town | Skipped on hosts with no city packs yet — re-run after `gc init`. |
+
+What it does NOT do (intentionally — these need human decisions):
+
+- **`gc init <name>`** — depends on what you call the city.
+- **`gc rig add <path>`** — depends on which projects you want to host.
+- **`peers.toml`** — depends on which other cities you want to reach
+  and what their gateway URLs are.
+- **Token distribution** — security-sensitive; tokens must move
+  out-of-band to peers.
+- **Polecat warm-pool config** — depends on rig load profile (see
+  `agent-scaling.md` "Cost of warm pools").
+
+## Manual follow-up checklist
+
+### A. Initialize the city (if not yet)
+
+```bash
+gc init my-new-city
+cd ~/my-new-city
+gc rig add /path/to/project1 --include packs/gastown
+gc rig add /path/to/project2 --include packs/gastown
+```
+
+If you're joining an existing shared-prefix rig, use `gc-rig-join`
+instead of `gc rig add` — see `docs/shared-rig-prefix.md`.
+
+After `gc init`, re-run the bootstrap with `--skip-helpers=0` (default)
+so the fix-* helpers patch the freshly-installed embedded packs:
+
+```bash
+~/.gc/bin/gc-city-bootstrap
+```
+
+### B. Edit ~/.gc/peers.toml
+
+Copy the template + fill in peer entries:
+
+```bash
+cp ~/dv-gascity-utils/packs/gascity-comms/assets/templates/peers.toml.template ~/.gc/peers.toml
+chmod 600 ~/.gc/peers.toml
+$EDITOR ~/.gc/peers.toml
+```
+
+Each peer entry needs:
+
+```toml
+[peers.<peer-city-name>]
+url = "http://<peer-tailscale-ip>:8472"
+token_file = "/Users/<you>/.gc/tokens/<peer-host>-gateway.token"
+```
+
+`token_file` should point at a per-peer token you've placed at that
+path. The token authenticates THIS host to the peer's gateway — so the
+peer generated it, not you. (Yours, in `~/.gc/tokens/<this-host>-gateway.token`,
+goes the OTHER direction: peers store it under that filename to talk
+to you.)
+
+### C. Distribute your gateway token to peers
+
+Out-of-band channel of your choice (encrypted Slack DM, signal, an SSH
+copy, whatever). Each peer puts your token at:
+
+```
+~/.gc/tokens/<this-host>-gateway.token  (mode 0600)
+```
+
+…where `<this-host>` matches the city name in their `peers.toml`. They
+then add an entry to their own `peers.toml` pointing at your gateway URL.
+
+Verify the round-trip:
+
+```bash
+# From this host, addressing a peer:
+gcx mail send <peer-city>:mayor -s "ping" -m "first contact from $(hostname -s)"
+
+# From the peer, addressing you (after they've set up their side):
+gcx mail send <this-city>:mayor -s "pong" -m "received"
+
+# Both sides should see the wisp arrive in their inbox via:
+gc mail inbox
+```
+
+If the send fails with `403 Unauthorized`, the token is wrong. If it
+fails with `connection refused`, the gateway isn't running on the
+target. If it succeeds but the recipient doesn't see the wisp, check
+`~/.gc/gateway/access.log` on the receiving side.
+
+### D. Polecat scaling overrides
+
+The default polecat `min_active_sessions` is `0` (cold pool). If you
+want a warm polecat per rig — faster first-claim latency at the cost
+of one idle session per rig — add `[[rigs.overrides]]` blocks per
+`docs/agent-scaling.md`.
+
+Heuristic: leave it cold (the default) unless you've observed
+first-claim latency pain on a specific rig. Warm-pool churn is real
+(see "Cost of warm pools" section in that doc).
+
+### E. Verify the host is healthy
+
+```bash
+# Helpers are on PATH and runnable
+ls ~/.gc/bin/gc-* | head -10
+
+# Watcher is alive and running v2
+launchctl list | grep dv-gascity.fix-watch
+tail -3 ~/Library/Logs/gc-fix-watch.log
+# expect: a recent 'baseline:' line
+
+# Gateway is listening on Tailscale interface
+launchctl list | grep dev.gascity.gateway
+tail -3 ~/.gc/gateway/launchd.out.log
+# expect: 'serving initial configuration'
+
+# Pack-tree pool fields are canonical
+grep '^pool ' ~/<city>/.gc/system/packs/dolt/orders/mol-dog-*.toml
+# expect: pool = "gastown.dog"
+
+# Audit reports clean
+~/.gc/bin/gc-audit-alias-mismatch ~/<city>
+# expect: 'no short-form findings'
+```
+
+## Known caveats this host will hit
+
+The new host will see the same gc binary bugs documented in
+`docs/known-binary-bugs.md`. Specifically:
+
+- **Pack-template wipe on supervisor startup**: `gc-fix-watch` is
+  installed by the bootstrap, so this is auto-handled in steady state.
+  If the watcher crashes, KeepAlive restarts it (PR #8 set-e fix).
+- **dolt/orders/* dog orders permanently stuck after bd-error**: not
+  preventable host-side. Symptoms appear days into operation. See the
+  "Supervisor restart — caveats and workaround" section in
+  `docs/diagnostic-runbook.md` for the manual workaround when it hits.
+- **`gc supervisor stop` may ignore SIGTERM**: same runbook section
+  has the SIGKILL escalation.
+
+Read `known-binary-bugs.md` end-to-end before going into production.
+Every entry has a workaround and a tracker.
+
+## Going further
+
+- `docs/cross-city-comms.md` — gateway architecture, peers.toml schema,
+  full setup detail (this doc summarizes; that one is canonical).
+- `docs/cross-city-mail-protocol.md` — wire format for cross-city wisps;
+  body-line-1 origin convention.
+- `docs/multi-city-shared-dolt.md` — running multiple cities against a
+  shared Dolt server.
+- `docs/agent-scaling.md` — `[[rigs.overrides]]` for per-rig agent
+  scaling tweaks.
+- `docs/diagnostic-runbook.md` — recovery recipes when things go wrong.
+- `docs/pack-template-resilience.md` — gc-fix-watch design + Linux
+  systemd unit template.
+
+## When the bootstrap script can't help
+
+- **Air-gapped host**: clone dv-gascity-utils manually from a tarball,
+  then run `gc-city-bootstrap` with `$DV_REPO_PATH` already populated.
+- **Custom Tailscale topology** (multiple interfaces, etc): pass
+  `--ts-ip` explicitly.
+- **Non-default homebrew location**: the gateway plist hardcodes
+  `/opt/homebrew/bin/caddy`. Edit before loading if Caddy lives
+  elsewhere.
+- **Linux**: the script ships LaunchAgent plists (macOS only). Linux
+  hosts use the systemd unit at
+  `packs/gascity-comms/assets/systemd/gc-fix-watch.service.template`
+  and a similar systemd unit for the gateway (write your own —
+  template not yet shipped here).

--- a/packs/gascity-comms/assets/scripts/gc-city-bootstrap
+++ b/packs/gascity-comms/assets/scripts/gc-city-bootstrap
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# gc-city-bootstrap — host-local prep for a new Gas City deployment.
+#
+# What this script does (idempotent, safe to re-run):
+#
+#   1. Clones (or fast-forwards) ~/dv-gascity-utils.
+#   2. Symlinks the gascity-comms helpers into ~/.gc/bin/.
+#   3. Generates a per-host gateway token if missing.
+#   4. Drops a Caddyfile + launchd plist for the gateway, substituting
+#      {{HOME}} and {{TS_IP}} in templates.
+#   5. Drops the gc-fix-watch LaunchAgent plist with {{HOME}}.
+#   6. Loads both LaunchAgents (gateway + fix-watch).
+#   7. Runs each gc-fix-* helper once against discovered towns to
+#      apply the in-place pack patches that survive templater wipes.
+#
+# What this script does NOT do (manual still required):
+#
+#   - gc init <city-name> + gc rig add — depends on the operator's
+#     intended rig topology.
+#   - peers.toml editing + token distribution to peer hosts — these
+#     are security-sensitive and require coordination with peer
+#     operators.
+#   - Tailscale IP override — auto-detected via `tailscale ip -4` when
+#     available, falls back to interactive prompt or --ts-ip flag.
+#   - Polecat min_active config in city.toml — Mayor's job; depends on
+#     rig profile (see docs/agent-scaling.md "Cost of warm pools").
+#
+# After this script: read docs/new-city-bootstrap.md for the manual
+# follow-up steps + verification checklist.
+#
+# Tracking: dv-gascity-utils PR adding this script.
+
+set -euo pipefail
+
+DV_REPO_URL="https://github.com/DataViking-Tech/dv-gascity-utils"
+DV_REPO_PATH="$HOME/dv-gascity-utils"
+BIN_DIR="$HOME/.gc/bin"
+TOKEN_DIR="$HOME/.gc/tokens"
+GATEWAY_DIR="$HOME/.gc/gateway"
+LAUNCHD_DIR="$HOME/Library/LaunchAgents"
+
+DRY_RUN=0
+TS_IP=""
+HOST_NAME="$(hostname -s)"
+SKIP_HELPERS=0
+
+usage() {
+    cat <<'EOF'
+gc-city-bootstrap — host-local prep for a new Gas City deployment.
+
+Usage:
+  gc-city-bootstrap [options]
+
+Options:
+  --dry-run           Print what would happen; touch nothing.
+  --ts-ip=<addr>      Tailscale IP for the gateway to bind. Default:
+                      detected via `tailscale ip -4` if available.
+  --skip-helpers      Skip the run-once gc-fix-* invocation. Use when
+                      no city packs are installed yet.
+  -h, --help          Show this help.
+
+Examples:
+  gc-city-bootstrap                          # full bootstrap
+  gc-city-bootstrap --dry-run                # preview only
+  gc-city-bootstrap --ts-ip 100.99.0.42      # explicit Tailscale IP
+  gc-city-bootstrap --skip-helpers           # skip pack-tree patching
+
+After running, see docs/new-city-bootstrap.md for the manual steps.
+EOF
+}
+
+log() { printf '[gc-city-bootstrap] %s\n' "$*"; }
+warn() { printf '[gc-city-bootstrap] warn: %s\n' "$*" >&2; }
+die() { printf '[gc-city-bootstrap] error: %s\n' "$*" >&2; exit 1; }
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '[gc-city-bootstrap] would run: %s\n' "$*"
+    else
+        "$@"
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --skip-helpers) SKIP_HELPERS=1; shift ;;
+        --ts-ip=*) TS_IP="${1#--ts-ip=}"; shift ;;
+        --ts-ip)
+            shift
+            [ $# -gt 0 ] || die "--ts-ip requires an argument"
+            TS_IP="$1"; shift ;;
+        *) die "unknown option: $1" ;;
+    esac
+done
+
+# 1. Clone or fast-forward dv-gascity-utils.
+if [ ! -d "$DV_REPO_PATH/.git" ]; then
+    log "step 1/7: cloning $DV_REPO_URL → $DV_REPO_PATH"
+    run git clone "$DV_REPO_URL" "$DV_REPO_PATH"
+else
+    log "step 1/7: fast-forwarding $DV_REPO_PATH"
+    run git -C "$DV_REPO_PATH" fetch --quiet origin main
+    run git -C "$DV_REPO_PATH" merge --quiet --ff-only origin/main || \
+        warn "could not fast-forward (local changes?); using current state"
+fi
+
+# 2. Symlink helpers into ~/.gc/bin/.
+log "step 2/7: symlinking helpers into $BIN_DIR"
+run mkdir -p "$BIN_DIR"
+HELPERS=(
+    "gcx"
+    "gc-fix-merge-strategy"
+    "gc-fix-alias-mismatch"
+    "gc-audit-alias-mismatch"
+    "gc-fix-watch"
+    "gc-rig-join"
+    "gc-warm-rig-pool"
+    "gc-tune-refinery-loop"
+    "gc-fix-refinery-routing"
+    "gc-city-bootstrap"
+)
+for h in "${HELPERS[@]}"; do
+    src="$DV_REPO_PATH/packs/gascity-comms/assets/scripts/$h"
+    dst="$BIN_DIR/$h"
+    if [ -e "$src" ]; then
+        run ln -sf "$src" "$dst"
+    else
+        warn "missing helper source: $src (skipping symlink)"
+    fi
+done
+
+# 3. Generate gateway token if missing.
+log "step 3/7: ensuring gateway token at $TOKEN_DIR/$HOST_NAME-gateway.token"
+run mkdir -p "$TOKEN_DIR"
+run chmod 700 "$TOKEN_DIR"
+TOKEN_FILE="$TOKEN_DIR/$HOST_NAME-gateway.token"
+if [ ! -f "$TOKEN_FILE" ]; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "would generate token: openssl rand -hex 32 > $TOKEN_FILE"
+    else
+        openssl rand -hex 32 > "$TOKEN_FILE"
+        chmod 600 "$TOKEN_FILE"
+        log "generated new gateway token (32 bytes hex). Distribute to peer hosts via secure channel."
+    fi
+else
+    log "token already exists at $TOKEN_FILE — leaving as-is"
+fi
+
+# 4. Caddyfile for the gateway.
+log "step 4/7: ensuring gateway Caddyfile at $GATEWAY_DIR/Caddyfile"
+run mkdir -p "$GATEWAY_DIR"
+
+if [ -z "$TS_IP" ]; then
+    if command -v tailscale >/dev/null 2>&1; then
+        TS_IP="$(tailscale ip -4 2>/dev/null | head -1 || true)"
+    fi
+fi
+
+if [ -z "$TS_IP" ]; then
+    warn "could not auto-detect Tailscale IP. Re-run with --ts-ip=<addr> to set."
+    warn "Skipping Caddyfile + gateway plist install. Helpers are still ready."
+else
+    log "using Tailscale IP: $TS_IP"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "would write $GATEWAY_DIR/Caddyfile with TS_IP=$TS_IP"
+    else
+        cat > "$GATEWAY_DIR/Caddyfile" <<EOF
+{
+    auto_https off
+    admin off
+    log {
+        output file $GATEWAY_DIR/access.log
+        format console
+    }
+}
+
+http://$TS_IP:8472 {
+    bind $TS_IP
+    @authorized header Authorization "Bearer {env.GC_GATEWAY_TOKEN}"
+
+    handle @authorized {
+        reverse_proxy 127.0.0.1:8372 {
+            header_up X-GC-Request 1
+            header_up -Authorization
+        }
+    }
+
+    handle {
+        respond "unauthorized" 401
+    }
+}
+EOF
+    fi
+fi
+
+# 5. LaunchAgent plists (macOS).
+if [ "$(uname -s)" = "Darwin" ]; then
+    log "step 5/7: ensuring LaunchAgent plists in $LAUNCHD_DIR"
+    run mkdir -p "$LAUNCHD_DIR"
+
+    # gc-fix-watch plist (always installable; no Tailscale dependency).
+    FIX_WATCH_TEMPLATE="$DV_REPO_PATH/packs/gascity-comms/assets/launchd/com.dv-gascity.fix-watch.plist.template"
+    FIX_WATCH_PLIST="$LAUNCHD_DIR/com.dv-gascity.fix-watch.plist"
+    if [ -f "$FIX_WATCH_TEMPLATE" ]; then
+        if [ "$DRY_RUN" -eq 1 ]; then
+            log "would render $FIX_WATCH_TEMPLATE → $FIX_WATCH_PLIST"
+        else
+            sed "s|{{HOME}}|$HOME|g" "$FIX_WATCH_TEMPLATE" > "$FIX_WATCH_PLIST"
+        fi
+    else
+        warn "missing $FIX_WATCH_TEMPLATE — skipping fix-watch plist install"
+    fi
+
+    # Gateway plist requires GC_GATEWAY_TOKEN env injection. Template
+    # ships in dv-gascity-utils only if available; otherwise we leave a
+    # commented-out skeleton for the operator to finish manually.
+    GATEWAY_PLIST="$LAUNCHD_DIR/dev.gascity.gateway.plist"
+    if [ -n "$TS_IP" ] && [ ! -f "$GATEWAY_PLIST" ]; then
+        if [ "$DRY_RUN" -eq 1 ]; then
+            log "would write $GATEWAY_PLIST"
+        else
+            cat > "$GATEWAY_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>dev.gascity.gateway</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>export GC_GATEWAY_TOKEN="\$(cat $TOKEN_FILE)" &amp;&amp; exec /opt/homebrew/bin/caddy run --config $GATEWAY_DIR/Caddyfile</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>StandardOutPath</key><string>$GATEWAY_DIR/launchd.out.log</string>
+    <key>StandardErrorPath</key><string>$GATEWAY_DIR/launchd.err.log</string>
+    <key>ThrottleInterval</key><integer>10</integer>
+</dict>
+</plist>
+EOF
+        fi
+    fi
+
+    # 6. Load LaunchAgents.
+    log "step 6/7: loading LaunchAgents"
+    if [ -f "$FIX_WATCH_PLIST" ]; then
+        run launchctl bootout "gui/$(id -u)/com.dv-gascity.fix-watch" 2>/dev/null || true
+        run launchctl bootstrap "gui/$(id -u)" "$FIX_WATCH_PLIST"
+    fi
+    if [ -f "$GATEWAY_PLIST" ]; then
+        run launchctl bootout "gui/$(id -u)/dev.gascity.gateway" 2>/dev/null || true
+        run launchctl bootstrap "gui/$(id -u)" "$GATEWAY_PLIST"
+    fi
+else
+    log "step 5/7 + 6/7: non-Darwin host detected. Use systemd unit"
+    log "  template at packs/gascity-comms/assets/systemd/gc-fix-watch.service.template"
+    log "  per docs/pack-template-resilience.md."
+fi
+
+# 7. Run gc-fix-* helpers once against discovered towns.
+if [ "$SKIP_HELPERS" -eq 1 ]; then
+    log "step 7/7: --skip-helpers requested; not running fix-* helpers"
+else
+    log "step 7/7: running gc-fix-* helpers against discovered towns"
+    TOWNS=()
+    for d in "$HOME"/*; do
+        [ -d "$d/.gc/system/packs" ] && TOWNS+=("$d")
+    done
+    if [ ${#TOWNS[@]} -eq 0 ]; then
+        log "no towns found under \$HOME/* with .gc/system/packs/. Run 'gc init <name>' first."
+    else
+        for town in "${TOWNS[@]}"; do
+            log "  scanning $town"
+            for fixer in "$BIN_DIR"/gc-fix-*; do
+                [ -x "$fixer" ] || continue
+                base="$(basename "$fixer")"
+                # Skip the watcher — that's a daemon, not a one-shot.
+                [ "$base" = "gc-fix-watch" ] && continue
+                # Skip the bootstrap itself.
+                [ "$base" = "gc-city-bootstrap" ] && continue
+                # Skip deprecated shim.
+                [ "$base" = "gc-fix-refinery-routing" ] && continue
+                run "$fixer" "$town"
+            done
+        done
+    fi
+fi
+
+log "done. See docs/new-city-bootstrap.md for manual follow-up steps:"
+log "  - Edit ~/.gc/peers.toml from the template."
+log "  - Distribute $TOKEN_FILE securely to peer hosts."
+log "  - Run 'gc init <city-name>' to initialize a city if not yet."
+log "  - Apply polecat min_active=0 overrides per docs/agent-scaling.md."


### PR DESCRIPTION
## Summary

Adds `gc-city-bootstrap`, a one-shot idempotent script that wraps the mechanical pieces of new-host setup, plus `docs/new-city-bootstrap.md` walking the end-to-end recipe with the manual follow-up checklist.

Closes the gap surfaced in our coordination thread: *"could a new city be scaffolded?"* Today the answer is **yes, with a 7-step manual recipe stitched together from 4 different docs.** After this: **yes, with one script + one linear checklist doc.**

## What's automated

`gc-city-bootstrap` does the mechanical, non-decision steps:

1. Clone or fast-forward `~/dv-gascity-utils`
2. Symlink every gascity-comms helper into `~/.gc/bin/`
3. Generate per-host gateway token if missing (`openssl rand 32B hex`, mode 0600)
4. Render `~/.gc/gateway/Caddyfile` (auto-detects Tailscale IP via `tailscale ip -4`; `--ts-ip` override available)
5. Render LaunchAgent plists for fix-watch + gateway (macOS; Linux uses systemd templates)
6. Load both LaunchAgents via `launchctl bootout` + `bootstrap`
7. Run each `gc-fix-*` helper once against discovered towns

Idempotent — re-running on a partially-set-up host is safe.

## What stays manual (intentionally)

These are operator decisions the script can't make:

- `gc init <city-name>` — depends on naming choice
- `gc rig add` — depends on which projects to host
- `peers.toml` editing — depends on peer topology
- Token distribution to peer hosts — security-sensitive, must move out-of-band
- Polecat warm-pool overrides — rig-load-profile decision

`docs/new-city-bootstrap.md` walks each of these as a checklist with verification commands.

## Verified locally

```
$ /Users/mani/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-city-bootstrap --dry-run
[gc-city-bootstrap] step 1/7: fast-forwarding /Users/mani/dv-gascity-utils
[gc-city-bootstrap] step 2/7: symlinking helpers into /Users/mani/.gc/bin
[gc-city-bootstrap] step 3/7: ensuring gateway token at /Users/mani/.gc/tokens/<host>-gateway.token
[gc-city-bootstrap] step 4/7: ensuring gateway Caddyfile at /Users/mani/.gc/gateway/Caddyfile
[gc-city-bootstrap] using Tailscale IP: 100.121.222.11
[gc-city-bootstrap] step 5/7: ensuring LaunchAgent plists ...
[gc-city-bootstrap] step 6/7: loading LaunchAgents
[gc-city-bootstrap] step 7/7: running gc-fix-* helpers against discovered towns
```

Tailscale IP auto-detect works; existing token preserved on re-run; Caddyfile would render with the right interface binding.

## Test plan

- [x] Dry-run on yg with existing setup: detects existing repo, existing token, current Tailscale IP. Idempotent.
- [ ] mg-mayor dry-runs on midgard host
- [ ] Fresh-host validation when next opportunity arises (e.g. asgard reset, or a brand new city)
- [ ] Linux fresh-host validation (systemd path is documented but not exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)