### PR TITLE
fix: gc-fix-runtime-restart helper for the request-restart panic

### DIFF
--- a/docs/known-binary-bugs.md
+++ b/docs/known-binary-bugs.md
@@ -164,7 +164,7 @@ Full sequence in `docs/diagnostic-runbook.md` — "Safe restart sequence".
 
 ## gc runtime request-restart panics with select-no-cases deadlock
 
-**Trackers**: `mg-fl2u8` (open).
+**Trackers**: `mg-fl2u8` (closed per 2026-04-30 directive — no binary modifications planned), `dgu-fl2u8` (closed mirror), `yg-ueadi` (closed dup filed by synth-panel/gastown.witness 2026-04-30 hitting it during patrol).
 
 **Symptom**: `gc runtime request-restart` (called by deacon and other agents to signal a clean restart) panics with Go runtime deadlock detection instead of blocking until the controller kills the session.
 
@@ -176,7 +176,18 @@ main.doRuntimeRequestRestart cmd_runtime_drain.go:462 +0x158
 
 **Why this happens**: the implementation uses a `select{}` with no cases, which Go's runtime detects as definite deadlock at goroutine 1. Should be a blocking channel or signal-bound context instead.
 
-**Workaround**: none. The metadata side-effect (`GC_RESTART_REQUESTED`) may or may not be set before the panic; agents calling this should NOT depend on the contract. Reconcile via the controller's metadata watcher instead.
+**Workaround (Class B)**: replace `gc runtime request-restart` with `gc runtime drain-ack && exit` in agent formulas. drain-ack signals the controller to stop the session (the polecat done-and-exit pattern); controller respawns from the agent template (driven by `min_active_sessions` or queued work), and the new session picks up the next wisp from its hook.
+
+`gc-fix-runtime-restart` patches the 4 affected formulas (mol-witness-patrol, mol-deacon-patrol, mol-refinery-patrol, mol-polecat-work) in the gastown pack. `gc-fix-watch` re-applies after every templater wipe — same pattern as `gc-fix-merge-strategy` and `gc-fix-alias-mismatch`.
+
+```bash
+ln -sf ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-fix-runtime-restart \
+    ~/.gc/bin/gc-fix-runtime-restart
+gc-fix-runtime-restart                       # patch every host town
+gc-fix-runtime-restart --dry-run ~/yggdrasil # preview one town
+```
+
+The metadata side-effect (`GC_RESTART_REQUESTED`) is no longer the contract anyone depends on after this fix.
 
 ---
 

--- a/packs/gascity-comms/assets/scripts/gc-fix-runtime-restart
+++ b/packs/gascity-comms/assets/scripts/gc-fix-runtime-restart
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# gc-fix-runtime-restart — replace broken `gc runtime request-restart` with
+# the working `gc runtime drain-ack && exit` pattern in agent formulas.
+#
+# WHY:
+#   `gc runtime request-restart` panics with "all goroutines asleep -
+#   deadlock! select (no cases)" at cmd_runtime_drain.go:462. Tracker:
+#   mg-fl2u8 / dgu-fl2u8 (closed per 2026-04-30 directive — no binary
+#   modifications). The replacement command is `gc runtime drain-ack`
+#   followed by `exit` — semantically equivalent to what request-restart
+#   was supposed to do (signal controller, terminate, controller
+#   respawns). Polecats already use drain-ack at end-of-cycle; this just
+#   makes patrol agents (witness, deacon, refinery) follow the same
+#   pattern.
+#
+# Files patched (skipped silently if absent):
+#   formulas/mol-witness-patrol.toml
+#   formulas/mol-deacon-patrol.toml
+#   formulas/mol-refinery-patrol.toml
+#   formulas/mol-polecat-work.toml
+#
+# Idempotent: marker check. Once the standalone bare-line and inline
+# backtick-wrapped references are gone, the helper reports "already
+# fixed".
+#
+# Pair with gc-fix-watch — the watcher will re-apply automatically after
+# every supervisor templater wipe.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+gc-fix-runtime-restart — replace broken request-restart with drain-ack && exit.
+
+Usage:
+  gc-fix-runtime-restart [options] [town-root ...]
+
+Default scan: every $HOME/<town>/.gc/system/packs/gastown that exists.
+Pass explicit town-root paths as positional args to override discovery.
+
+Options:
+  --dry-run     Show what would change; touch nothing.
+  -h, --help    Show this help.
+
+Examples:
+  gc-fix-runtime-restart                       # scan ~/* and patch every gastown pack
+  gc-fix-runtime-restart --dry-run             # preview without writing
+  gc-fix-runtime-restart ~/yggdrasil ~/asgard  # explicit roots
+EOF
+}
+
+DRY_RUN=0
+ROOTS=()
+
+die() { echo "gc-fix-runtime-restart: $*" >&2; exit 2; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --) shift; while [ $# -gt 0 ]; do ROOTS+=("$1"); shift; done ;;
+        -*) die "unknown option: $1" ;;
+        *) ROOTS+=("$1"); shift ;;
+    esac
+done
+
+command -v perl >/dev/null 2>&1 || die "perl is required but not installed"
+
+if [ ${#ROOTS[@]} -eq 0 ]; then
+    for d in "$HOME"/*; do
+        [ -d "$d/.gc/system/packs/gastown" ] && ROOTS+=("$d")
+    done
+    [ ${#ROOTS[@]} -gt 0 ] || die "no .gc/system/packs/gastown trees found under $HOME/*; pass an explicit town root"
+fi
+
+# Two patterns:
+#   (1) Standalone bare-line command in bash blocks:
+#         gc runtime request-restart
+#       → rewrite to:
+#         gc runtime drain-ack && exit
+#
+#   (2) Inline backtick-wrapped reference (Markdown tables / prose):
+#         `gc runtime request-restart`
+#       → rewrite to:
+#         `gc runtime drain-ack && exit`
+#
+# Both are anchored exactly so we don't rewrite hypothetical other
+# surfaces (e.g., a comment that says "the request-restart command is
+# broken — use ..." would NOT match because the helper only rewrites
+# the command itself).
+
+PERL_BARE='s{^gc runtime request-restart\s*$}{gc runtime drain-ack && exit}'
+PERL_INLINE='s{`gc runtime request-restart`}{`gc runtime drain-ack && exit`}g'
+
+# Detection greps. If neither matches, the file is already fixed.
+GREP_BARE='^gc runtime request-restart\s*$'
+GREP_INLINE='`gc runtime request-restart`'
+
+TARGET_FILES=(
+    "formulas/mol-witness-patrol.toml"
+    "formulas/mol-deacon-patrol.toml"
+    "formulas/mol-refinery-patrol.toml"
+    "formulas/mol-polecat-work.toml"
+)
+
+files_changed=0
+files_skipped=0
+files_already_fixed=0
+
+for town in "${ROOTS[@]}"; do
+    pack_root="$town/.gc/system/packs/gastown"
+    [ -d "$pack_root" ] || { echo "  skip: $town (no gastown pack)"; continue; }
+    town_label="$(basename "$town")"
+
+    for rel in "${TARGET_FILES[@]}"; do
+        file="$pack_root/$rel"
+        if [ ! -f "$file" ]; then
+            files_skipped=$((files_skipped + 1))
+            continue
+        fi
+
+        bare_count=$(grep -cE "$GREP_BARE" "$file" 2>/dev/null || true)
+        bare_count="${bare_count:-0}"
+        inline_count=$(grep -cF -- "$GREP_INLINE" "$file" 2>/dev/null || true)
+        inline_count="${inline_count:-0}"
+        total=$((bare_count + inline_count))
+
+        if [ "$total" -eq 0 ]; then
+            echo "  ok (already fixed): $town_label/$rel"
+            files_already_fixed=$((files_already_fixed + 1))
+            continue
+        fi
+
+        if [ "$DRY_RUN" -eq 1 ]; then
+            printf '  would fix [%d bare + %d inline = %d]: %s/%s\n' \
+                "$bare_count" "$inline_count" "$total" "$town_label" "$rel"
+            files_changed=$((files_changed + 1))
+            continue
+        fi
+
+        # Run both substitutions. Combine with `; ` so perl applies them
+        # sequentially in one pass.
+        perl -i -pe "$PERL_BARE; $PERL_INLINE" "$file"
+
+        # Verify rewrite landed.
+        bare_after=$(grep -cE "$GREP_BARE" "$file" 2>/dev/null || true)
+        bare_after="${bare_after:-0}"
+        inline_after=$(grep -cF -- "$GREP_INLINE" "$file" 2>/dev/null || true)
+        inline_after="${inline_after:-0}"
+        applied=$((total - bare_after - inline_after))
+
+        if [ "$applied" -le 0 ]; then
+            printf '  warn: no changes applied to %s/%s (matched but rewrite did nothing)\n' \
+                "$town_label" "$rel" >&2
+            continue
+        fi
+
+        printf '  fixed [%d substitution(s)]: %s/%s\n' "$applied" "$town_label" "$rel"
+        files_changed=$((files_changed + 1))
+    done
+done
+
+echo
+if [ "$files_changed" -eq 0 ] && [ "$files_already_fixed" -gt 0 ]; then
+    printf 'gc-fix-runtime-restart: %d file(s) already fixed; nothing to do.\n' "$files_already_fixed"
+elif [ "$DRY_RUN" -eq 1 ]; then
+    printf 'gc-fix-runtime-restart: %d file(s) would be patched. Re-run without --dry-run to apply.\n' "$files_changed"
+else
+    printf 'gc-fix-runtime-restart: %d file(s) patched, %d already fixed.\n' "$files_changed" "$files_already_fixed"
+fi


### PR DESCRIPTION
## Summary

Class B workaround for the \`gc runtime request-restart\` deadlock panic (mg-fl2u8 / dgu-fl2u8 — closed under the new no-binary-modifications directive). Replaces the broken command in 4 gastown formulas with the working \`gc runtime drain-ack && exit\` pattern that polecats already use.

Surfaced concretely today by **yg-ueadi** — synth-panel/gastown.witness hit the panic during patrol and filed an escalation. Without this fix every patrol agent (witness/deacon/refinery) eventually hits the same trap.

## Why drain-ack works

\`drain-ack\` is the established pattern: signals the controller to stop the session, returns immediately, then \`exit\` terminates the agent. Controller's reconciler sees the session gone and respawns from the agent template (\`min_active_sessions\` or queued work driven). New session resumes from the next wisp on its hook.

Same end-state as \`request-restart\` was supposed to provide, minus the deadlock panic. Polecats use this daily at end-of-cycle.

## Files patched

| File | Substitutions |
|------|---------------|
| \`formulas/mol-witness-patrol.toml\` | 2 (bare standalone command in bash blocks) |
| \`formulas/mol-deacon-patrol.toml\` | 2 |
| \`formulas/mol-refinery-patrol.toml\` | 1 |
| \`formulas/mol-polecat-work.toml\` | 1 (inline backtick reference in Markdown table) |

Two perl substitutions, anchored:
- \`^gc runtime request-restart\\s*$\` → \`gc runtime drain-ack && exit\` (bare line)
- `` \\\`gc runtime request-restart\\\` `` → `` \\\`gc runtime drain-ack && exit\\\` `` (inline)

## Verified on yg

\`\`\`
$ gc-fix-runtime-restart --dry-run /Users/mani/yggdrasil
  would fix [2 bare + 0 inline = 2]: yggdrasil/formulas/mol-witness-patrol.toml
  would fix [2 bare + 0 inline = 2]: yggdrasil/formulas/mol-deacon-patrol.toml
  would fix [1 bare + 0 inline = 1]: yggdrasil/formulas/mol-refinery-patrol.toml
  would fix [0 bare + 1 inline = 1]: yggdrasil/formulas/mol-polecat-work.toml

$ gc-fix-runtime-restart /Users/mani/yggdrasil
[applies 6 substitutions]

$ gc-fix-runtime-restart /Users/mani/yggdrasil
gc-fix-runtime-restart: 4 file(s) already fixed; nothing to do.
\`\`\`

Idempotent. \`gc-fix-watch\` will pick up the new helper automatically (it dispatches every \`~/.gc/bin/gc-fix-*\`).

## Catalog updated

\`docs/known-binary-bugs.md\` entry for \`mg-fl2u8\` now references this helper as the Class B workaround instead of \"none.\" Tracker statuses updated (mg-fl2u8 / dgu-fl2u8 / yg-ueadi all closed).

## Test plan

- [x] yg: dry-run + apply + idempotency check (above)
- [ ] mg: dry-run via \`gc-fix-runtime-restart --dry-run /Users/openclaw/midgard\`; apply when convenient
- [ ] Reviewer eyeballs the perl substitutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)