### PR TITLE
feat: gc-fix-refinery-pr-body — keep refinery PR-body patch alive across re-imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Per-host symlinks the bootstrap script handles automatically:
 
 ```bash
 for h in gcx gc-rig-join gc-audit-alias-mismatch gc-fix-alias-mismatch \
-         gc-fix-refinery-routing gc-fix-merge-strategy gc-fix-watch \
-         gc-warm-rig-pool gc-tune-refinery-loop gc-city-bootstrap; do
+         gc-fix-refinery-routing gc-fix-merge-strategy gc-fix-refinery-pr-body \
+         gc-fix-watch gc-warm-rig-pool gc-tune-refinery-loop gc-city-bootstrap; do
     ln -sf "$HOME/dv-gascity-utils/packs/gascity-comms/assets/scripts/$h" "$HOME/.gc/bin/$h"
 done
 cp ~/dv-gascity-utils/packs/gascity-comms/assets/templates/peers.toml.template ~/.gc/peers.toml
@@ -86,9 +86,10 @@ fixes:
 ```bash
 gc-fix-alias-mismatch ~/<town>     # or just `gc-fix-alias-mismatch` to scan ~/*
 gc-fix-merge-strategy ~/<town>
+gc-fix-refinery-pr-body ~/<town>
 ```
 
-Both are idempotent — re-runs report `already fixed`. See
+All three are idempotent — re-runs report `already fixed`. See
 `docs/alias-canonicalization.md` and `docs/rig-merge-strategy.md` for
 what each one rewrites and why.
 

--- a/packs/gascity-comms/assets/scripts/gc-fix-refinery-pr-body
+++ b/packs/gascity-comms/assets/scripts/gc-fix-refinery-pr-body
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# gc-fix-refinery-pr-body — make refinery `mr` PRs include `Closes #N`,
+# the GitHub issue link, work bead ID, commit log, blockquoted issue
+# context, and a test-plan checklist.
+#
+# Without this fix, the refinery's `mr`-strategy `PR_BODY` heredoc is a
+# 3-line stub:
+#
+#   ## Summary
+#   Automated pull request published by Gastown Refinery.
+#   - Issue: $WORK
+#   - Branch: $BRANCH
+#   - Target: $TARGET
+#
+# Reviewers have to leave the PR to find the original GitHub issue, and
+# the bead's `external_ref` (already populated by the mayor when
+# creating beads from GitHub issues, e.g. `--external-ref gh-343`) is
+# thrown away. This helper patches the heredoc to derive a `Closes #N`
+# closing keyword and a clickable issue URL from `external_ref`, plus
+# the commit log and the bead description as blockquoted context.
+#
+# This helper patches the refinery formula in every gastown system pack
+# found on this host. Each town's `.gc/system/packs/gastown/` is a
+# runtime copy that is not in any git repo, so the only authoritative
+# way to apply the fix locally is in-place (same pattern as
+# gc-fix-merge-strategy and gc-fix-refinery-routing).
+#
+# Files touched per pack (skipped silently if absent):
+#   formulas/mol-refinery-patrol.toml
+#
+# Idempotent: rewrite is guarded by a marker check (looks for
+# `EXTERNAL_REF=` in the merge-push step). Fixed packs report
+# "already fixed".
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+gc-fix-refinery-pr-body — enrich the refinery's mr-strategy PR body.
+
+Usage:
+  gc-fix-refinery-pr-body [options] [town-root ...]
+
+Default scan: every $HOME/<town>/.gc/system/packs/gastown that exists.
+Pass explicit town-root paths as positional args to override discovery.
+
+Options:
+  --dry-run     Show what would change; touch nothing.
+  -h, --help    Show this help.
+
+Examples:
+  gc-fix-refinery-pr-body                       # scan ~/* and patch every gastown pack
+  gc-fix-refinery-pr-body --dry-run             # preview without writing
+  gc-fix-refinery-pr-body ~/yggdrasil ~/asgard  # explicit roots
+EOF
+}
+
+DRY_RUN=0
+ROOTS=()
+
+die() { echo "gc-fix-refinery-pr-body: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --) shift; while [ $# -gt 0 ]; do ROOTS+=("$1"); shift; done ;;
+        -*) die "unknown option: $1" ;;
+        *) ROOTS+=("$1"); shift ;;
+    esac
+done
+
+if [ ${#ROOTS[@]} -eq 0 ]; then
+    for d in "$HOME"/*; do
+        [ -d "$d/.gc/system/packs/gastown" ] && ROOTS+=("$d")
+    done
+fi
+
+[ ${#ROOTS[@]} -gt 0 ] || die "no gastown system packs found under $HOME/*; pass explicit roots"
+
+# patch_with_python <file> <python-script>
+patch_with_python() {
+    local file="$1" script="$2"
+    if [ ! -f "$file" ]; then
+        echo "    skip (missing): ${file#$HOME/}"
+        return
+    fi
+    local tmp; tmp=$(mktemp)
+    if ! python3 -c "$script" <"$file" >"$tmp"; then
+        rm -f "$tmp"
+        die "python patch failed on $file"
+    fi
+    if cmp -s "$file" "$tmp"; then
+        rm -f "$tmp"
+        echo "    ok (already fixed): ${file#$HOME/}"
+        return
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        rm -f "$tmp"
+        echo "    would edit: ${file#$HOME/}"
+        return
+    fi
+    mv "$tmp" "$file"
+    echo "    fixed: ${file#$HOME/}"
+}
+
+# Patch script for formulas/mol-refinery-patrol.toml.
+# Replaces the literal stub PR_BODY heredoc in the merge-push step
+# (under `**If MERGE_STRATEGY = "mr":**`) with an enriched variant
+# that pulls external_ref, bead description, commit log, and renders
+# `Closes #N` + GitHub issue URL when external_ref matches `gh-N`.
+read -r -d '' FORMULA_PATCH <<'PYEOF' || true
+import sys, re
+
+src = sys.stdin.read()
+
+# Marker: the patched version assigns EXTERNAL_REF in the merge-push
+# step. If that variable is set anywhere in the file, treat as
+# already patched.
+if re.search(r'^EXTERNAL_REF=', src, re.MULTILINE):
+    sys.stdout.write(src)
+    sys.exit(0)
+
+# Match the literal stub block. Anchored on the EXISTING_PR line that
+# starts the section, through the closing EOF + ) of the heredoc.
+old = '''EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
+ISSUE_TITLE=$(gc bd show $WORK --json | jq -r '.[0].title')
+PR_BODY=$(cat <<EOF
+## Summary
+
+Automated pull request published by Gastown Refinery.
+
+- Issue: $WORK
+- Branch: $BRANCH
+- Target: $TARGET
+
+EOF
+)'''
+
+new = '''EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
+ISSUE_TITLE=$(gc bd show $WORK --json | jq -r '.[0].title')
+EXTERNAL_REF=$(gc bd show $WORK --json | jq -r '.[0].external_ref // empty')
+BEAD_DESC=$(gc bd show $WORK --json | jq -r '.[0].description // ""' | sed 's/^/> /' | head -60)
+COMMIT_LOG=$(git log --oneline "origin/$TARGET..$BRANCH" 2>/dev/null | head -15)
+GH_ISSUE_LINK=""
+GH_ISSUE_REF=""
+if echo "$EXTERNAL_REF" | grep -qE '^gh-[0-9]+$'; then
+  GH_ISSUE_NUM="${EXTERNAL_REF#gh-}"
+  GH_ISSUE_LINK="https://github.com/$ORIGIN_REPO/issues/$GH_ISSUE_NUM"
+  GH_ISSUE_REF="Closes #$GH_ISSUE_NUM"
+fi
+PR_BODY=$(cat <<EOF
+## Summary
+
+Automated pull request published by Gastown Refinery for work bead \\`$WORK\\`.
+
+${GH_ISSUE_REF:+$GH_ISSUE_REF}
+${GH_ISSUE_LINK:+- **GitHub issue:** $GH_ISSUE_LINK}
+${EXTERNAL_REF:+- **External ref:** \\`$EXTERNAL_REF\\`}
+- **Work bead:** \\`$WORK\\`
+- **Branch:** \\`$BRANCH\\` → \\`$TARGET\\`
+
+## Changes
+
+\\`\\`\\`
+$COMMIT_LOG
+\\`\\`\\`
+
+## Issue context
+
+$BEAD_DESC
+
+## Test plan
+
+- [ ] CI checks pass on this PR
+- [ ] Acceptance criteria from the linked issue verified
+- [ ] No regressions in adjacent surfaces
+
+---
+Published by Gastown Refinery (rig: \\`${GC_RIG:-unknown}\\`).
+EOF
+)'''
+
+if old not in src:
+    sys.stderr.write(
+        "gc-fix-refinery-pr-body: the literal stub PR_BODY block was not found in "
+        "the input file. The upstream formula may have shifted shape — re-check the "
+        "patch heredoc against the current `**If MERGE_STRATEGY = \"mr\":**` section "
+        "of mol-refinery-patrol.toml and update the `old` string in this helper.\n"
+    )
+    sys.exit(2)
+
+sys.stdout.write(src.replace(old, new, 1))
+PYEOF
+
+echo "Scanning ${#ROOTS[@]} root(s):"
+printf '  %s\n' "${ROOTS[@]}"
+echo
+
+for root in "${ROOTS[@]}"; do
+    pack="$root/.gc/system/packs/gastown"
+    [ -d "$pack" ] || { echo "  skip (no gastown pack): ${root#$HOME/}"; continue; }
+    echo "  ${pack#$HOME/}:"
+    patch_with_python "$pack/formulas/mol-refinery-patrol.toml" "$FORMULA_PATCH"
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo
+    echo "dry-run complete; no files were changed"
+else
+    echo
+    echo "done. Re-run safely; subsequent runs report 'already fixed'."
+fi


### PR DESCRIPTION
## Summary

Companion helper for the refinery PR-body adjustment in #15. That PR documented the patch (`Closes #N` + GitHub issue link, work-bead ID, commit log, blockquoted issue context, test-plan checklist) and acknowledged the durability gap: the system pack at `~/<town>/.gc/system/packs/gastown/` is not git-tracked, so the patch gets reverted whenever gc re-renders the pack. **Verified empirically this turn** — direct edit lasted ~90 minutes, was reverted before the next refinery cycle, next mr-strategy PR (#389 on SynthPanel) came out with the bare 3-line stub body again.

This helper closes that gap. Same shape as `gc-fix-merge-strategy` and `gc-fix-refinery-routing`:

- Scans every `~/<town>/.gc/system/packs/gastown/` and applies the `PR_BODY` substitution under a marker check.
- Idempotent — re-runs on already-patched packs report `already fixed`. Marker is the `EXTERNAL_REF=` assignment in the merge-push step (only present in the patched form).
- Discoverable by `gc-fix-watch` because the script is named `gc-fix-*` and lives in `~/.gc/bin/` after the standard symlink install. `gc-fix-watch` re-runs every `gc-fix-*` helper after a pack tree change, so a `gc pack import` that wipes the patch triggers re-application within 30s.
- Surfaces a clear stderr message + exit 2 if the upstream stub block has shifted shape (so the patch heredoc can be updated rather than silently failing).

## Verified

```
$ gc-fix-refinery-pr-body
Scanning 2 root(s):
  /Users/mani/asgard
  /Users/mani/yggdrasil

  asgard/.gc/system/packs/gastown:
    fixed: asgard/.gc/system/packs/gastown/formulas/mol-refinery-patrol.toml
  yggdrasil/.gc/system/packs/gastown:
    fixed: yggdrasil/.gc/system/packs/gastown/formulas/mol-refinery-patrol.toml

done. Re-run safely; subsequent runs report 'already fixed'.

$ gc-fix-refinery-pr-body
  asgard/.gc/system/packs/gastown:
    ok (already fixed): asgard/.gc/system/packs/gastown/formulas/mol-refinery-patrol.toml
  yggdrasil/.gc/system/packs/gastown:
    ok (already fixed): yggdrasil/.gc/system/packs/gastown/formulas/mol-refinery-patrol.toml
```

## Files

- `packs/gascity-comms/assets/scripts/gc-fix-refinery-pr-body` — new helper, 200 lines, mirrors `gc-fix-merge-strategy` structure.
- `README.md` — adds `gc-fix-refinery-pr-body` to the symlink install loop and to the post-symlink-run sequence ("All three are idempotent...").

## Test plan

- [x] First run on yg + asgard fixes both packs.
- [x] Second run reports both as already fixed.
- [x] `--dry-run` previews without writing.
- [x] After `gc-fix-watch`'s next cycle (~30s), the patched formula is observable via `grep EXTERNAL_REF= ~/<town>/.gc/system/packs/gastown/formulas/mol-refinery-patrol.toml`.
- [ ] Once a refinery cycle runs on a freshly-patched host, the next `mr`-strategy PR's body shows `Closes #N` + the GitHub issue link.

## See also

- DataViking-Tech/dv-gascity-utils#15 — refinery PR-body adjustment doc (references this helper as the durability path).
- DataViking-Tech/dv-gascity-utils#17 — host-local prime inline pattern (separate fix, similar shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)