### PR TITLE
fix(gc-fix-refinery-pr-body): drop invalid \` escape in TOML basic string

### DIFF
--- a/packs/gascity-comms/assets/scripts/gc-fix-refinery-pr-body
+++ b/packs/gascity-comms/assets/scripts/gc-fix-refinery-pr-body
@@ -152,19 +152,19 @@ fi
 PR_BODY=$(cat <<EOF
 ## Summary
 
-Automated pull request published by Gastown Refinery for work bead \\`$WORK\\`.
+Automated pull request published by Gastown Refinery for work bead `$WORK`.
 
 ${GH_ISSUE_REF:+$GH_ISSUE_REF}
 ${GH_ISSUE_LINK:+- **GitHub issue:** $GH_ISSUE_LINK}
-${EXTERNAL_REF:+- **External ref:** \\`$EXTERNAL_REF\\`}
-- **Work bead:** \\`$WORK\\`
-- **Branch:** \\`$BRANCH\\` → \\`$TARGET\\`
+${EXTERNAL_REF:+- **External ref:** `$EXTERNAL_REF`}
+- **Work bead:** `$WORK`
+- **Branch:** `$BRANCH` → `$TARGET`
 
 ## Changes
 
-\\`\\`\\`
+```
 $COMMIT_LOG
-\\`\\`\\`
+```
 
 ## Issue context
 
@@ -177,7 +177,7 @@ $BEAD_DESC
 - [ ] No regressions in adjacent surfaces
 
 ---
-Published by Gastown Refinery (rig: \\`${GC_RIG:-unknown}\\`).
+Published by Gastown Refinery (rig: `${GC_RIG:-unknown}`).
 EOF
 )'''
 


### PR DESCRIPTION
## Summary

The patched `PR_BODY` heredoc embedded markdown backticks as `\` + `` ` `` which the Python triple-quoted string rendered as `\` + `` ` `` in the substitution, which then landed in the formula's `description = """..."""` TOML basic string. **TOML basic strings don't recognize `\` + `` ` `` as a valid escape**. Result: every patched `mol-refinery-patrol.toml` failed to parse, the formula was silently dropped from the registry, and any fresh refinery on the host couldn't pour patrol wisps.

## How it surfaced

`synth-bench/gastown.refinery-1` came up on a fresh rig this turn and escalated:

```
gc bd mol wisp mol-refinery-patrol fails: "'mol-refinery-patrol' not found as formula or proto"
TOML parse error at line 435: "invalid escape in string '\\`'"
only 9 of 10 formulas listed.
```

Yg + asgard had been running the same broken file since the helper first applied (PR #18), but their refineries kept using the old in-memory formula state from before the wipe. Synth-bench was the **first fresh refinery to actually try to load the file post-patch**.

## Fix

Backticks have no special meaning in TOML basic strings — the escape itself is what's invalid. Just write them as-is.

The output PR body goes through `gh pr create --body "..."` as a quoted argument; bash command-substitution semantics never apply, so the bare backticks pass through cleanly to the rendered markdown.

## What's in this PR

- Drops the `\` before each `` ` `` in the helper's `new` heredoc (the substitution that lands in the TOML).
- Drops the same escape in the triple-backtick code-fence around `$COMMIT_LOG`.

## Out-of-band repair

Yg + asgard's broken formula files have already been hand-fixed via `sed`:

```
sed -i '' 's/\\`/`/g' \
    ~/<town>/.gc/system/packs/gastown/formulas/mol-refinery-patrol.toml
```

After the sed, `gc bd formula show mol-refinery-patrol` parses cleanly on both packs. Fresh refinery on synth-bench unblocked.

The marker check (`EXTERNAL_REF=`) is unchanged, so the helper still recognizes already-patched files and reports `ok (already fixed)`. The hand-fix preserves the marker, so a re-run of the helper on those packs is a no-op.

## Test plan

- [x] `bash -n gc-fix-refinery-pr-body` — passes.
- [x] Hand-fix verified on yg + asgard: `gc bd formula show mol-refinery-patrol` returns the formula.
- [x] Helper dry-run on yg + asgard: `ok (already fixed)` (marker intact).
- [ ] On a fresh pack import that wipes the patch, helper re-application produces a parseable TOML.
- [ ] First refinery cycle on a freshly-patched pack produces a valid PR body with `Closes #N` + GitHub issue link.

## See also

- DataViking-Tech/dv-gascity-utils#18 — the helper this fixes (already merged).
- DataViking-Tech/dv-gascity-utils#15 — refinery PR-body docs (still open). Both reference this same patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)