### PR TITLE
feat(gc-fix-control-dispatcher): flip named_session.mode always→on_demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ DataViking-Tech utilities and patterns for [Gas City](https://docs.gascityhall.c
 
 ### Packs
 
-- **`packs/gascity-comms/`** — cross-city mail tooling. Ships `gcx` (city-aware mail wrapper), the `mail-nudge` order (auto-wakes recipient sessions when their inbox grows), `gc-rig-join` (joins an existing shared-prefix rig from a second city — see `docs/shared-rig-prefix.md`), `gc-audit-alias-mismatch` + `gc-fix-alias-mismatch` (find and rewrite short-form agent aliases to canonical `<rig>/gastown.<role>` across installed system packs; idempotent — see `docs/alias-canonicalization.md`; supersedes the narrower `gc-fix-refinery-routing`, preserved as a deprecation shim), a doctor check (`doctor/check-alias-mismatch`) that surfaces drift, `doctor/check-cross-city-prime-wiring` (warns when the pack is imported but the host hasn't completed the per-host opt-in to wire `cross-city-prime` into the mayor template — see `docs/mayor-prompt-prime-recipe.md`), `doctor/check-bin-symlinks` (walks `~/.gc/bin/` and fails on broken helper symlinks; flags out-of-tree targets informationally — catches the case where a symlink target is moved or deleted out from under it without `gc-city-bootstrap` being re-run), `gc-fix-merge-strategy` (one-shot: makes the polecat done-sequence auto-detect PR-protected branches and set `metadata.merge_strategy=mr` so the refinery opens a PR instead of failing GH013 on direct merge — see `docs/rig-merge-strategy.md`), a peers.toml template, the `collaborative-loop-suggest` mayor-prompt template fragment (see `docs/collaborative-loops.md`), and the `cross-city-prime` template fragment (orients freshly-restarted mayor sessions to the cross-city setup — see `docs/mayor-prompt-prime-recipe.md`). Importable into any Gas City workspace.
+- **`packs/gascity-comms/`** — cross-city mail tooling. Ships `gcx` (city-aware mail wrapper), the `mail-nudge` order (auto-wakes recipient sessions when their inbox grows), `gc-rig-join` (joins an existing shared-prefix rig from a second city — see `docs/shared-rig-prefix.md`), `gc-audit-alias-mismatch` + `gc-fix-alias-mismatch` (find and rewrite short-form agent aliases to canonical `<rig>/gastown.<role>` across installed system packs; idempotent — see `docs/alias-canonicalization.md`; supersedes the narrower `gc-fix-refinery-routing`, preserved as a deprecation shim), a doctor check (`doctor/check-alias-mismatch`) that surfaces drift, `doctor/check-cross-city-prime-wiring` (warns when the pack is imported but the host hasn't completed the per-host opt-in to wire `cross-city-prime` into the mayor template — see `docs/mayor-prompt-prime-recipe.md`), `doctor/check-bin-symlinks` (walks `~/.gc/bin/` and fails on broken helper symlinks; flags out-of-tree targets informationally — catches the case where a symlink target is moved or deleted out from under it without `gc-city-bootstrap` being re-run), `gc-fix-merge-strategy` (one-shot: makes the polecat done-sequence auto-detect PR-protected branches and set `metadata.merge_strategy=mr` so the refinery opens a PR instead of failing GH013 on direct merge — see `docs/rig-merge-strategy.md`), `gc-fix-control-dispatcher` (one-shot, idempotent: flips the `control-dispatcher` named-session from `mode = "always"` to `mode = "on_demand"` in the embedded gastown pack so the reconciler stops keeping a permanent dispatcher slot alive — eliminates the dead-`env`-shell tmux orphan leak; pair with `gc-fix-watch` so re-templates don't revert it), a peers.toml template, the `collaborative-loop-suggest` mayor-prompt template fragment (see `docs/collaborative-loops.md`), and the `cross-city-prime` template fragment (orients freshly-restarted mayor sessions to the cross-city setup — see `docs/mayor-prompt-prime-recipe.md`). Importable into any Gas City workspace.
 
 ### Docs
 
@@ -74,7 +74,8 @@ Per-host symlinks the bootstrap script handles automatically:
 ```bash
 for h in gcx gc-rig-join gc-audit-alias-mismatch gc-fix-alias-mismatch \
          gc-fix-refinery-routing gc-fix-merge-strategy gc-fix-refinery-pr-body \
-         gc-fix-watch gc-warm-rig-pool gc-tune-refinery-loop gc-city-bootstrap; do
+         gc-fix-control-dispatcher gc-fix-watch gc-warm-rig-pool \
+         gc-tune-refinery-loop gc-city-bootstrap; do
     ln -sf "$HOME/dv-gascity-utils/packs/gascity-comms/assets/scripts/$h" "$HOME/.gc/bin/$h"
 done
 cp ~/dv-gascity-utils/packs/gascity-comms/assets/templates/peers.toml.template ~/.gc/peers.toml
@@ -90,9 +91,10 @@ fixes:
 gc-fix-alias-mismatch ~/<town>     # or just `gc-fix-alias-mismatch` to scan ~/*
 gc-fix-merge-strategy ~/<town>
 gc-fix-refinery-pr-body ~/<town>
+gc-fix-control-dispatcher ~/<town>
 ```
 
-All three are idempotent — re-runs report `already fixed`. See
+All are idempotent — re-runs report `already fixed`. See
 `docs/alias-canonicalization.md` and `docs/rig-merge-strategy.md` for
 what each one rewrites and why.
 

--- a/packs/gascity-comms/assets/scripts/gc-city-bootstrap
+++ b/packs/gascity-comms/assets/scripts/gc-city-bootstrap
@@ -115,6 +115,7 @@ HELPERS=(
     "gc-fix-alias-mismatch"
     "gc-audit-alias-mismatch"
     "gc-fix-runtime-restart"
+    "gc-fix-control-dispatcher"
     "gc-fix-watch"
     "gc-events-rotate"
     "gc-rig-init"

--- a/packs/gascity-comms/assets/scripts/gc-fix-control-dispatcher
+++ b/packs/gascity-comms/assets/scripts/gc-fix-control-dispatcher
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# gc-fix-control-dispatcher — flip named_session.mode always→on_demand on
+# the gc-binary-embedded `control-dispatcher.toml` template under each
+# town's gastown system pack.
+#
+# WHY:
+#   The `control-dispatcher` named-session has mode = "always" in the
+#   gastown pack rendered to disk by the gc binary. The reconciler keeps
+#   a dispatcher session alive at all times; when one is torn down (pool
+#   reconciler cleanup, idle exit, restart), tmux occasionally fails to
+#   kill the pty, leaving a dead `env` shell as an orphan. Observed:
+#   ~14 orphans/hr steady-state, ~970/hr during reconciler churn (~44x
+#   normal). 100% of leaked sessions match this template; no other
+#   template leaks. Tracked upstream as dv-gascity-utils#23 / gc-bn0c.
+#
+#   Flipping to mode = "on_demand" means the slot only spawns when the
+#   reconciler determines a sling needs dispatching — no always-live
+#   slot, no teardown leak.
+#
+# Files patched (skipped silently if absent):
+#   any file named `control-dispatcher.toml` under
+#   <town>/.gc/system/packs/gastown
+#
+# Idempotent: marker check. Once `mode = "always"` is gone from the
+# matched files, the helper reports "already fixed".
+#
+# Pair with gc-fix-watch — the watcher will re-apply automatically after
+# every supervisor templater wipe.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+gc-fix-control-dispatcher — flip control-dispatcher named_session.mode always→on_demand.
+
+Usage:
+  gc-fix-control-dispatcher [options] [town-root ...]
+
+Default scan: every $HOME/<town>/.gc/system/packs/gastown that exists.
+Pass explicit town-root paths as positional args to override discovery.
+
+Options:
+  --dry-run     Show what would change; touch nothing.
+  -h, --help    Show this help.
+
+Examples:
+  gc-fix-control-dispatcher                        # scan ~/* and patch every gastown pack
+  gc-fix-control-dispatcher --dry-run              # preview without writing
+  gc-fix-control-dispatcher ~/yggdrasil ~/asgard   # explicit roots
+EOF
+}
+
+DRY_RUN=0
+ROOTS=()
+
+die() { echo "gc-fix-control-dispatcher: $*" >&2; exit 2; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --) shift; while [ $# -gt 0 ]; do ROOTS+=("$1"); shift; done ;;
+        -*) die "unknown option: $1" ;;
+        *) ROOTS+=("$1"); shift ;;
+    esac
+done
+
+command -v perl >/dev/null 2>&1 || die "perl is required but not installed"
+
+if [ ${#ROOTS[@]} -eq 0 ]; then
+    for d in "$HOME"/*; do
+        [ -d "$d/.gc/system/packs/gastown" ] && ROOTS+=("$d")
+    done
+    [ ${#ROOTS[@]} -gt 0 ] || die "no .gc/system/packs/gastown trees found under $HOME/*; pass an explicit town root"
+fi
+
+# Pattern: bare-line `mode = "always"` rewritten to `mode = "on_demand"`.
+# Anchored exactly so we don't rewrite hypothetical other surfaces (e.g.
+# a comment that mentions mode = "always" would NOT match). The trailing
+# class is `[ \t]*` (horizontal whitespace only) so `$` doesn't consume
+# the line's terminating newline — `\s*$` would, joining the patched
+# line into the next one.
+PERL_BARE='s{^mode = "always"[ \t]*$}{mode = "on_demand"}'
+
+GREP_BARE='^mode = "always"[[:space:]]*$'
+
+files_changed=0
+files_skipped=0
+files_already_fixed=0
+
+for town in "${ROOTS[@]}"; do
+    pack_root="$town/.gc/system/packs/gastown"
+    [ -d "$pack_root" ] || { echo "  skip: $town (no gastown pack)"; continue; }
+    town_label="$(basename "$town")"
+
+    # Collect any control-dispatcher.toml under the gastown pack. The gc
+    # binary embeds this file at compile time and may render it to a path
+    # that varies by version (e.g. agents/control-dispatcher/, named_sessions/),
+    # so search by basename rather than fixed relative path.
+    found=()
+    while IFS= read -r -d '' f; do
+        found+=("$f")
+    done < <(find "$pack_root" -type f -name 'control-dispatcher.toml' -print0 2>/dev/null)
+
+    if [ ${#found[@]} -eq 0 ]; then
+        echo "  skip: $town_label (no control-dispatcher.toml under gastown pack)"
+        files_skipped=$((files_skipped + 1))
+        continue
+    fi
+
+    for file in "${found[@]}"; do
+        rel="${file#$pack_root/}"
+        bare_count=$(grep -cE "$GREP_BARE" "$file" 2>/dev/null || true)
+        bare_count="${bare_count:-0}"
+
+        if [ "$bare_count" -eq 0 ]; then
+            echo "  ok (already fixed): $town_label/$rel"
+            files_already_fixed=$((files_already_fixed + 1))
+            continue
+        fi
+
+        if [ "$DRY_RUN" -eq 1 ]; then
+            printf '  would fix [%d match(es)]: %s/%s\n' "$bare_count" "$town_label" "$rel"
+            files_changed=$((files_changed + 1))
+            continue
+        fi
+
+        perl -i -pe "$PERL_BARE" "$file"
+
+        bare_after=$(grep -cE "$GREP_BARE" "$file" 2>/dev/null || true)
+        bare_after="${bare_after:-0}"
+        applied=$((bare_count - bare_after))
+
+        if [ "$applied" -le 0 ]; then
+            printf '  warn: no changes applied to %s/%s (matched but rewrite did nothing)\n' \
+                "$town_label" "$rel" >&2
+            continue
+        fi
+
+        printf '  fixed [%d substitution(s)]: %s/%s\n' "$applied" "$town_label" "$rel"
+        files_changed=$((files_changed + 1))
+    done
+done
+
+echo
+if [ "$files_changed" -eq 0 ] && [ "$files_already_fixed" -gt 0 ]; then
+    printf 'gc-fix-control-dispatcher: %d file(s) already fixed; nothing to do.\n' "$files_already_fixed"
+elif [ "$DRY_RUN" -eq 1 ]; then
+    printf 'gc-fix-control-dispatcher: %d file(s) would be patched. Re-run without --dry-run to apply.\n' "$files_changed"
+else
+    printf 'gc-fix-control-dispatcher: %d file(s) patched, %d already fixed.\n' "$files_changed" "$files_already_fixed"
+fi


### PR DESCRIPTION
## Summary

Implements the `gc-fix-control-dispatcher` helper for [issue #23](https://github.com/DataViking-Tech/dv-gascity-utils/issues/23) — flips named-session `mode = always` to `mode = on_demand` so the controller stops the tmux orphan-leak that fires when always-on sessions exit + restart in tight loops.

Polecat work bead: `dgu-al90e` (work bead created on mg-side and slung into the dv-gascity-utils pool, picked up by yg's furiosa polecat). Branch pushed and bead handed to dv-gascity-utils refinery; opening this PR on the refinery's behalf because the supervisor's beads-cache reconciler is currently wedged (separate issue, being investigated).

## Files

- `packs/gascity-comms/assets/scripts/gc-fix-control-dispatcher` — new helper following the established `gc-fix-*` shape (idempotent marker check, dry-run mode, scans every `~/<town>/.gc/system/packs/gastown/` per host).
- `packs/gascity-comms/assets/scripts/gc-city-bootstrap` — adds `gc-fix-control-dispatcher` to the symlink-install loop alongside the other `gc-fix-*` helpers.
- `README.md` — index entry pointing at the new helper.

## Test plan

- [x] `bash -n gc-fix-control-dispatcher` — syntax OK (verified by polecat).
- [ ] CI lint passes on this PR.
- [ ] Apply on yg + mg via `gc-fix-control-dispatcher ~/<town>` post-merge.
- [ ] Verify the named_session.mode flip is observable in `~/<town>/.gc/system/packs/gastown/agents/*/named_session.toml` after apply.
- [ ] Idempotency: second run reports `already fixed`.
- [ ] Tmux-orphan symptom (the issue's actual fix-target) requires soak time on a long-running session to verify; flagging as the manual-verify step.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)