### PR TITLE
[#26] gc-rig-join preflight: hardcoded empty password blocks auth'd dolt deployments (dgu-nku6b)

### DIFF
--- a/packs/gascity-comms/assets/scripts/gc-rig-join
+++ b/packs/gascity-comms/assets/scripts/gc-rig-join
@@ -21,6 +21,18 @@
 
 set -euo pipefail
 
+# Source ~/.gc/secrets.env if present so GC_DOLT_USER / GC_DOLT_PASSWORD become
+# the defaults for the preflight dolt calls. Matches `gc`'s own discovery path
+# (every `gc dolt sql` call already honors these vars). Without this, the raw
+# `dolt` invocations below cannot reach an authenticated shared server.
+GC_HOME="${GC_HOME:-$HOME/.gc}"
+if [ -f "$GC_HOME/secrets.env" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    . "$GC_HOME/secrets.env"
+    set +a
+fi
+
 usage() {
     cat <<'EOF'
 gc-rig-join — join an existing shared-prefix rig from a second city.
@@ -35,7 +47,10 @@ Options:
   --name <name>          Rig name in the second city's site.toml (default: derived from path)
   --host <host>          Shared dolt host (default: 127.0.0.1)
   --port <port>          Shared dolt port (default: 16022)
-  --user <user>          Shared dolt user (default: root)
+  --user <user>          Shared dolt user (default: $GC_DOLT_USER or root)
+  --password <pw>        Shared dolt password (default: $GC_DOLT_PASSWORD,
+                         else $DOLT_CLI_PASSWORD, else $MYSQL_PWD, else empty)
+  --password-file <path> Read password from first line of file (overrides env)
   --pin-endpoint         After --adopt, also run `gc rig set-endpoint <name> --external …`
                          (use when the city's own dolt is NOT the shared one)
   --dry-run              Show what would be done; touch nothing
@@ -43,6 +58,11 @@ Options:
 
 The local-path is the directory holding the project's git clone on this host.
 It must already exist (you cloned the repo). This script creates `.beads/` inside it.
+
+Auth: ~/.gc/secrets.env is sourced if present (GC_DOLT_USER, GC_DOLT_PASSWORD).
+The hot-path operations (`gc dolt-state ensure-project-id`, `gc rig add --adopt`)
+already honor those vars via the `gc` binary; the preflight dolt calls below
+now do too. Override per-invocation with --user / --password / --password-file.
 
 Examples:
   # Second city joining `sp` (synth-panel) where the city already use-externals
@@ -66,7 +86,10 @@ PREFIX=""
 NAME=""
 HOST="127.0.0.1"
 PORT="16022"
-USER_="root"
+USER_="${GC_DOLT_USER:-root}"
+PASSWORD_FLAG=""
+PASSWORD_FILE=""
+PASSWORD_FROM_FLAG=0
 PIN_ENDPOINT=0
 DRY_RUN=0
 
@@ -103,6 +126,8 @@ while [ $# -gt 0 ]; do
         --host) HOST="${2:-}"; shift 2 ;;
         --port) PORT="${2:-}"; shift 2 ;;
         --user) USER_="${2:-}"; shift 2 ;;
+        --password) PASSWORD_FLAG="${2:-}"; PASSWORD_FROM_FLAG=1; shift 2 ;;
+        --password-file) PASSWORD_FILE="${2:-}"; shift 2 ;;
         --pin-endpoint) PIN_ENDPOINT=1; shift ;;
         --dry-run) DRY_RUN=1; shift ;;
         --) shift; break ;;
@@ -115,6 +140,26 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+# Resolve the dolt password used by the preflight dolt calls below.
+# Precedence: --password-file > --password > $GC_DOLT_PASSWORD >
+#             $DOLT_CLI_PASSWORD > $MYSQL_PWD > empty.
+# The `dolt` CLI honors DOLT_CLI_PASSWORD (we export it on each invocation),
+# so this resolution feeds that env var.
+if [ -n "$PASSWORD_FILE" ]; then
+    [ -r "$PASSWORD_FILE" ] || die "--password-file is not readable: $PASSWORD_FILE"
+    PASSWORD=$(head -n1 "$PASSWORD_FILE")
+elif [ "$PASSWORD_FROM_FLAG" -eq 1 ]; then
+    PASSWORD="$PASSWORD_FLAG"
+elif [ -n "${GC_DOLT_PASSWORD:-}" ]; then
+    PASSWORD="$GC_DOLT_PASSWORD"
+elif [ -n "${DOLT_CLI_PASSWORD:-}" ]; then
+    PASSWORD="$DOLT_CLI_PASSWORD"
+elif [ -n "${MYSQL_PWD:-}" ]; then
+    PASSWORD="$MYSQL_PWD"
+else
+    PASSWORD=""
+fi
 
 [ -n "$LOCAL" ]  || { usage >&2; exit 2; }
 [ -n "$PREFIX" ] || die "--prefix is required"
@@ -155,7 +200,8 @@ fi
 # Without this we'd fall through to ensure-project-id and surface a generic
 # "Error 1049 (HY000): database not found" — confusing for first-time joiners.
 if command -v dolt >/dev/null 2>&1; then
-    DBS_OUT=$(dolt --no-tls --user "$USER_" --password "" \
+    DBS_OUT=$(DOLT_CLI_PASSWORD="$PASSWORD" \
+              dolt --no-tls --user "$USER_" \
                    --host "$HOST" --port "$PORT" \
                    sql --query "SHOW DATABASES;" --result-format=csv 2>&1) || {
         die "cannot reach dolt server at $HOST:$PORT (user=$USER_): $(echo "$DBS_OUT" | head -1)"
@@ -169,7 +215,8 @@ if command -v dolt >/dev/null 2>&1; then
     # If the DB exists but is empty (someone created it manually for some other
     # purpose), `gc rig add --adopt` would happily wire us in and `bd list` would
     # then explode at first read. Catch it here.
-    TBLS=$(dolt --no-tls --user "$USER_" --password "" \
+    TBLS=$(DOLT_CLI_PASSWORD="$PASSWORD" \
+           dolt --no-tls --user "$USER_" \
                 --host "$HOST" --port "$PORT" \
                 sql --query "USE \`$PREFIX\`; SHOW TABLES;" --result-format=csv 2>&1) || {
         die "cannot enumerate tables in database '$PREFIX' on $HOST:$PORT: $(echo "$TBLS" | head -1)"


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery for work bead `dgu-nku6b`.

Closes #26
- **GitHub issue:** https://github.com/DataViking-Tech/dv-gascity-utils/issues/26
- **External ref:** `gh-26`
- **Work bead:** `dgu-nku6b`
- **Branch:** `polecat/dgu-nku6b` → `main`

## Changes

```
333e2e6 fix(gc-rig-join): preflight honors GC_DOLT_USER/PASSWORD from secrets.env
```

## Issue context

> TITLE: gc-rig-join preflight: hardcoded empty password blocks auth'd dolt deployments
> 
> BODY:
> ## Summary
> 
> `packs/gascity-comms/assets/scripts/gc-rig-join` runs two preflight `dolt sql` calls (lines 158, 172) with `--password ""` hardcoded, which fails with `Access denied for user 'X'` on any deployment whose shared dolt requires auth.
> 
> ```bash
> DBS_OUT=$(dolt --no-tls --user "$USER_" --password "" \
>     --host "$HOST" --port "$PORT" --query "SHOW DATABASES" 2>&1)
> ```
> 
> Concrete failure on midgard, 2026-05-02:
> 
> ```
> $ ~/.gc/bin/gc-rig-join ~/dv-gascity-utils --prefix dgu --name dv-gascity-utils \
>     --host mani-mac-mini.tail032ed9.ts.net --port 16022 --dry-run
> gc-rig-join: cannot reach dolt server at mani-mac-mini.tail032ed9.ts.net:16022 (user=root):
>   error on line 1 for query SHOW DATABASES:
>   Error 1045 (28000): Access denied for user 'root'
> 
> $ # tried --user beads — same auth failure (no way to pass the password)
> ```
> 
> mg's shared dolt requires auth (`GC_DOLT_USER=beads`, `GC_DOLT_PASSWORD=...` in `~/.gc/secrets.env`, picked up by every `gc dolt sql` call but not by raw `dolt`).
> 
> ## What works today
> 
> The hot-path operations in the script (`gc dolt-state ensure-project-id`, `gc rig add --adopt`) work fine — they go through the `gc` binary which honors `secrets.env`. So the script's actual job succeeds; only the preflight blocks it. Workaround on mg was to skip the script and run the steps manually, which loses the script's value as a one-shot helper.
> 
> ## Proposed fix
> 
> Have the preflight honor a password source. In rough preference order:
> 
> 1. `MYSQL_PWD` env (standard `mysql` CLI convention, also honored by the `dolt` binary).
> 2. New `--password <pw>` and `--password-file <path>` flags (matching `dolt sql`'s own surface).
> 3. Source `~/.gc/secrets.env` if present and read `GC_DOLT_PASSWORD` (matches `gc`'s own discovery path).
> 
> (1) alone would unblock mg without any flag-surface change — set `MYSQL_PWD=$GC_DOLT_PASSWORD` before invoking, or document the env-var requirement at the top of the script.
> 
> ## Affected lines
> 
> - `packs/gascity-comms/assets/scripts/gc-rig-join:158`
> - `packs/gascity-comms/assets/scripts/gc-rig-join:172`
> 
> Filed by: gastown.mayor on midgard, 2026-05-02. Pairs with the multi-city detect work in PR #24 — that work prevents duplicates by having every host run gc-rig-init/gc-rig-join, so anything blocking the join path on auth'd-dolt hosts is on the critical path now.
> 
> GitHub issue: https://github.com/DataViking-Tech/dv-gascity-utils/issues/26

## Test plan

- [ ] CI checks pass on this PR
- [ ] Acceptance criteria from the linked issue verified
- [ ] No regressions in adjacent surfaces

---
Published by Gastown Refinery (rig: `dv-gascity-utils`).