### PR TITLE
controller bd init: honor secrets.env (issue #29) (dgu-emwy6)

### DIFF
--- a/docs/known-binary-bugs.md
+++ b/docs/known-binary-bugs.md
@@ -361,6 +361,35 @@ The wrapper:
 
 ---
 
+## controller's per-rig `bd init` step doesn't honor secrets.env
+
+**Trackers**: `dgu-emwy6` (open). Upstream: [DataViking-Tech/dv-gascity-utils#29](https://github.com/DataViking-Tech/dv-gascity-utils/issues/29). Same root-cause family as #26 (`gc-rig-join` preflight) and the `DOLT_CLI_PASSWORD=""` pattern in `gc-rig-init` — three surfaces, one bug.
+
+**Symptom**: supervisor's per-rig `init rig <name> beads: exec beads init` step defaults to `dolt --user root --password ""` against the configured shared dolt. On hosts whose shared dolt requires auth (mg's `GC_DOLT_USER=beads` + `GC_DOLT_PASSWORD=…` in `~/.gc/secrets.env`), the bd init call hangs and gets SIGKILL'd by the supervisor's init timeout. The per-rig init then falls into a backoff retry loop and the entire city stays stuck never coming up. Cascades: subsequent reload requests get rejected ("keeping old config"), so any city.toml edits made after init failure are silently dropped.
+
+**Evidence**: mg, 2026-05-02:
+```
+gc supervisor: city 'midgard': init: beads lifecycle: init rig "dv-gascity-utils" beads:
+  exec beads init: signal: killed (skipping)
+gc supervisor: city 'midgard': init failure #3, next retry in 40s
+```
+
+**Root cause**: `gc-beads-bd.sh` (the bd-pack wrapper the supervisor execs) reads `${GC_DOLT_PASSWORD:-}` from its own environment. The supervisor doesn't pre-source `~/.gc/secrets.env`, so the var is unset. The wrapper's `bd init` invocation also doesn't pass `--server-user` / `BEADS_DOLT_PASSWORD`, so even if the env had been populated, bd would still default to root/empty.
+
+**Workaround (Class B)**: `gc-fix-bd-init-auth` patches the runtime `<city>/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh` to (a) source `~/.gc/secrets.env` early, with MYSQL_PWD ↔ GC_DOLT_PASSWORD bridging, and (b) pass `--server-user "$DOLT_USER"` + `BEADS_DOLT_PASSWORD="$DOLT_PASSWORD"` to the `bd init` call. Idempotent via marker checks.
+
+```bash
+ln -sf ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-fix-bd-init-auth \
+    ~/.gc/bin/gc-fix-bd-init-auth
+
+gc-fix-bd-init-auth --dry-run    # preview
+gc-fix-bd-init-auth              # apply across all towns under $HOME
+```
+
+`gc-fix-watch` re-applies after every supervisor templater wipe. On hosts without secrets.env (yg, asgard) the bootstrap block is a no-op — DOLT_USER stays `root` and DOLT_PASSWORD stays empty, matching pre-patch behavior.
+
+---
+
 ## Pack-template wipe on supervisor startup / heavy reconcile
 
 **Trackers**: discussed across `mg-d80k3`, `mg-ovjgn`, `mg-pfh96` threads. No primary bead — it's the underlying mechanism that creates Class B's reason-for-existing.

--- a/packs/gascity-comms/assets/scripts/gc-city-bootstrap
+++ b/packs/gascity-comms/assets/scripts/gc-city-bootstrap
@@ -116,6 +116,7 @@ HELPERS=(
     "gc-audit-alias-mismatch"
     "gc-fix-runtime-restart"
     "gc-fix-control-dispatcher"
+    "gc-fix-bd-init-auth"
     "gc-fix-watch"
     "gc-events-rotate"
     "gc-reload-orders"

--- a/packs/gascity-comms/assets/scripts/gc-fix-bd-init-auth
+++ b/packs/gascity-comms/assets/scripts/gc-fix-bd-init-auth
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# gc-fix-bd-init-auth — patch the bd-pack's gc-beads-bd.sh wrapper so the
+# supervisor's `init rig <name> beads: exec beads init` step picks up auth
+# credentials on hosts whose shared dolt requires a password.
+#
+# WHY:
+#   The supervisor invokes gc-beads-bd.sh from a clean environment that
+#   does not pre-source ~/.gc/secrets.env. On hosts where the shared dolt
+#   requires auth (mg's GC_DOLT_USER=beads + GC_DOLT_PASSWORD=… in
+#   ~/.gc/secrets.env), the bd init call defaults to root/empty-password,
+#   hangs, and gets SIGKILL'd by the supervisor's init timeout — blocking
+#   the entire city from coming up. Subsequent reload requests are then
+#   rejected ("keeping old config"), so the symptoms cascade until the
+#   rig is dropped from city.toml.
+#
+#   This helper applies two surgical edits to the wrapper:
+#
+#     1. Source ~/.gc/secrets.env at the top of the script (before
+#        DOLT_USER/DOLT_PASSWORD are read), and bridge MYSQL_PWD <->
+#        GC_DOLT_PASSWORD so any consumer that looks for the standard
+#        mysql/dolt env name also sees the password.
+#
+#     2. Pass --server-user "$DOLT_USER" and BEADS_DOLT_PASSWORD="$DOLT_PASSWORD"
+#        to the `bd init` invocation in op_init. Without this, bd defaults
+#        to root with no password regardless of what the wrapper read into
+#        DOLT_USER/DOLT_PASSWORD.
+#
+#   Tracked upstream as dv-gascity-utils#29. Same root-cause family as
+#   #26 (gc-rig-join preflight) and the gc-rig-init DOLT_CLI_PASSWORD=""
+#   pattern — separate fixes, one per surface.
+#
+# Files patched (skipped silently if absent):
+#   <town>/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh
+#
+# Idempotent: marker checks. Once both patches land, subsequent runs
+# report "already fixed".
+#
+# Pair with gc-fix-watch — the watcher will re-apply automatically after
+# every supervisor templater wipe of the bd pack.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+gc-fix-bd-init-auth — make the bd init wrapper honor secrets.env / MYSQL_PWD.
+
+Usage:
+  gc-fix-bd-init-auth [options] [town-root ...]
+
+Default scan: every $HOME/<town>/.gc/system/packs/bd that exists.
+Pass explicit town-root paths as positional args to override discovery.
+
+Options:
+  --dry-run     Show what would change; touch nothing.
+  -h, --help    Show this help.
+
+Examples:
+  gc-fix-bd-init-auth                          # scan ~/* and patch every bd pack
+  gc-fix-bd-init-auth --dry-run                # preview without writing
+  gc-fix-bd-init-auth ~/yggdrasil ~/asgard     # explicit roots
+EOF
+}
+
+DRY_RUN=0
+ROOTS=()
+
+die() { echo "gc-fix-bd-init-auth: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --) shift; while [ $# -gt 0 ]; do ROOTS+=("$1"); shift; done ;;
+        -*) die "unknown option: $1" ;;
+        *) ROOTS+=("$1"); shift ;;
+    esac
+done
+
+command -v python3 >/dev/null 2>&1 || die "python3 is required but not installed"
+
+if [ ${#ROOTS[@]} -eq 0 ]; then
+    for d in "$HOME"/*; do
+        [ -d "$d/.gc/system/packs/bd" ] && ROOTS+=("$d")
+    done
+fi
+
+[ ${#ROOTS[@]} -gt 0 ] || die "no .gc/system/packs/bd trees found under $HOME/*; pass an explicit town root"
+
+# patch_with_python <file> <python-script>
+# Returns the file with one patch applied. Idempotent at the python layer
+# (script writes input unchanged when its marker is already present).
+patch_with_python() {
+    local file="$1" script="$2" label="$3"
+    local tmp; tmp=$(mktemp)
+    if ! python3 -c "$script" <"$file" >"$tmp"; then
+        rm -f "$tmp"
+        die "python patch failed on $file ($label)"
+    fi
+    if cmp -s "$file" "$tmp"; then
+        rm -f "$tmp"
+        echo "    ok ($label, already fixed)"
+        return 0
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        rm -f "$tmp"
+        echo "    would patch ($label)"
+        return 0
+    fi
+    # Preserve the original mode (the wrapper is exec'd by the supervisor
+    # so the executable bit must survive the rewrite).
+    local orig_mode
+    orig_mode=$(stat -f '%Lp' "$file" 2>/dev/null || stat -c '%a' "$file" 2>/dev/null || echo 755)
+    mv "$tmp" "$file"
+    chmod "$orig_mode" "$file"
+    echo "    patched ($label)"
+}
+
+# --- Patch 1: insert auth bootstrap block above the DOLT_HOST assignment.
+# Sources ~/.gc/secrets.env if present and bridges MYSQL_PWD <->
+# GC_DOLT_PASSWORD so the wrapper reads the password the supervisor's
+# environment lacks. Marker: the literal "bd-init-auth: source" comment.
+read -r -d '' AUTH_BOOTSTRAP_PATCH <<'PYEOF' || true
+import sys
+src = sys.stdin.read()
+if "bd-init-auth: source" in src:
+    sys.stdout.write(src)
+    sys.exit(0)
+
+old = '''# --- Configuration ---
+
+# DOLT_PORT is set after derived paths are resolved (see allocate_port below).
+DOLT_HOST="${GC_DOLT_HOST:-0.0.0.0}"'''
+
+new = '''# --- Configuration ---
+
+# bd-init-auth: source ~/.gc/secrets.env so the supervisor's bd-init step
+# picks up GC_DOLT_USER/GC_DOLT_PASSWORD without the supervisor having to
+# pre-load the file itself. MYSQL_PWD is the standard mysql/dolt env name
+# and is bridged both directions so consumers that look for either name
+# find the password. Fixes dv-gascity-utils#29.
+if [ -z "${GC_DOLT_PASSWORD:-}" ] && [ -r "${HOME:-}/.gc/secrets.env" ]; then
+    set -a
+    . "${HOME}/.gc/secrets.env"
+    set +a
+fi
+if [ -z "${GC_DOLT_PASSWORD:-}" ] && [ -n "${MYSQL_PWD:-}" ]; then
+    GC_DOLT_PASSWORD="$MYSQL_PWD"
+fi
+if [ -z "${MYSQL_PWD:-}" ] && [ -n "${GC_DOLT_PASSWORD:-}" ]; then
+    MYSQL_PWD="$GC_DOLT_PASSWORD"
+    export MYSQL_PWD
+fi
+
+# DOLT_PORT is set after derived paths are resolved (see allocate_port below).
+DOLT_HOST="${GC_DOLT_HOST:-0.0.0.0}"'''
+
+if old not in src:
+    sys.stderr.write(
+        "gc-fix-bd-init-auth: anchor block for the auth bootstrap was not found. "
+        "The upstream wrapper may have shifted shape — re-check the "
+        "`# --- Configuration ---` / DOLT_HOST anchor in gc-beads-bd.sh and "
+        "update the `old` string in this helper.\n"
+    )
+    sys.exit(2)
+
+sys.stdout.write(src.replace(old, new, 1))
+PYEOF
+
+# --- Patch 2: enrich the bd init invocation with --server-user and the
+# BEADS_DOLT_PASSWORD env var. Without this, bd defaults to root/empty
+# even after patch 1 populates DOLT_USER/DOLT_PASSWORD — bd's auth flags
+# are independent of the wrapper's `dolt --user/--password` calls.
+# Marker: the literal `BEADS_DOLT_PASSWORD="$DOLT_PASSWORD" bd init`.
+read -r -d '' BD_INIT_PATCH <<'PYEOF' || true
+import sys
+src = sys.stdin.read()
+if 'BEADS_DOLT_PASSWORD="$DOLT_PASSWORD" bd init' in src:
+    sys.stdout.write(src)
+    sys.exit(0)
+
+old = '    (cd "$dir" && bd init --quiet --server -p "$init_prefix" --skip-hooks --skip-agents         --server-host "$host" --server-port "$DOLT_PORT"         "$dir") || die "bd init failed for $dir"'
+new = '    (cd "$dir" && BEADS_DOLT_PASSWORD="$DOLT_PASSWORD" bd init --quiet --server -p "$init_prefix" --skip-hooks --skip-agents         --server-host "$host" --server-port "$DOLT_PORT" --server-user "$DOLT_USER"         "$dir") || die "bd init failed for $dir"'
+
+if old not in src:
+    sys.stderr.write(
+        "gc-fix-bd-init-auth: literal `bd init` invocation in op_init was not "
+        "found. Re-check the line in gc-beads-bd.sh and update the `old` string "
+        "in this helper.\n"
+    )
+    sys.exit(2)
+
+sys.stdout.write(src.replace(old, new, 1))
+PYEOF
+
+echo "Scanning ${#ROOTS[@]} root(s):"
+printf '  %s\n' "${ROOTS[@]}"
+echo
+
+for root in "${ROOTS[@]}"; do
+    pack="$root/.gc/system/packs/bd"
+    [ -d "$pack" ] || { echo "  skip (no bd pack): ${root#$HOME/}"; continue; }
+    file="$pack/assets/scripts/gc-beads-bd.sh"
+    if [ ! -f "$file" ]; then
+        echo "  skip (no gc-beads-bd.sh): ${root#$HOME/}"
+        continue
+    fi
+    echo "  ${file#$HOME/}:"
+    patch_with_python "$file" "$AUTH_BOOTSTRAP_PATCH" "secrets.env bootstrap"
+    patch_with_python "$file" "$BD_INIT_PATCH" "bd init --server-user/BEADS_DOLT_PASSWORD"
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo
+    echo "dry-run complete; no files were changed"
+else
+    echo
+    echo "done. Re-run safely; subsequent runs report 'already fixed'."
+fi


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery for work bead `dgu-emwy6`.

Closes #29
- **GitHub issue:** https://github.com/DataViking-Tech/dv-gascity-utils/issues/29
- **External ref:** `gh-29`
- **Work bead:** `dgu-emwy6`
- **Branch:** `mayor/controller-bd-init-auth` → `main`

## Changes

```
795c2b1 feat(gc-fix-bd-init-auth): supervisor's bd init step honors secrets.env
```

## Issue context

> Upstream issue: https://github.com/DataViking-Tech/dv-gascity-utils/issues/29
> 
> The supervisor's per-rig 'init rig <name> beads: exec beads init' step defaults to dolt --user root --password "" against the shared dolt. On hosts where the shared dolt requires auth (mg's GC_DOLT_USER=beads + GC_DOLT_PASSWORD=... in ~/.gc/secrets.env), this hangs and gets SIGKILL'd by the supervisor's init timeout, blocking the entire city from coming up.
> 
> Same root-cause family as #26 (gc-rig-join preflight) and the gc-fix-refinery-pr-body warn (DOLT_CLI_PASSWORD="" hardcoded). Three places doing the same thing wrong.
> 
> Output expected:
> - Patch the bd init wrapper used by the supervisor's beads-lifecycle step to honor MYSQL_PWD env (cheapest), then --password / --password-file, then source ~/.gc/secrets.env if present
> - Same pattern as #26's proposed fix
> - Verify on mg by re-enabling the rig adoption that this currently blocks
> - PR against DataViking-Tech/dv-gascity-utils, --head mayor/controller-bd-init-auth, body links #29 with Closes #29
> 
> Repo: /Users/openclaw/dv-gascity-utils (clean, on main, pull first)
> Reference: ~/dv-gascity-utils/packs/gascity-comms/assets/scripts/gc-rig-join (similar auth pattern needed)

## Test plan

- [ ] CI checks pass on this PR
- [ ] Acceptance criteria from the linked issue verified
- [ ] No regressions in adjacent surfaces

---
Published by Gastown Refinery (rig: `dv-gascity-utils`).