### PR TITLE
chore: untrack .beads/ from version control

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,5 +1,0 @@
-issue_prefix: dgu
-issue-prefix: dgu
-dolt.auto-start: false
-gc.endpoint_origin: inherited_city
-gc.endpoint_status: verified

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,7 +1,0 @@
-{
-  "backend": "dolt",
-  "database": "dolt",
-  "dolt_database": "dgu",
-  "dolt_mode": "server",
-  "project_id": "gc-local-eedae9385a1d64e04ddf7b9041fdc10f"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,4 @@
 *~
 
 # Gas City
-.beads/*
-!.beads/config.yaml
-!.beads/metadata.json
+.beads/


### PR DESCRIPTION
## Summary

Untracks the committed `.beads/config.yaml` and `.beads/metadata.json` from version control, switching `.gitignore` from a selective allow-list to full-ignore. `.beads/` holds beads (bd) issue-tracker state — local agent working state, not source code.

The previous `.gitignore` had:

    .beads/*
    !.beads/config.yaml
    !.beads/metadata.json

…which kept those two files tracked across clones. This contributed to a class of install-time bugs where `gt rig add` collides with the committed local-state files.

**Parent rationale**: DataViking-Tech/traitprint#30

## What changes

- `git rm .beads/config.yaml .beads/metadata.json`
- `.gitignore`: replaced the selective allow-list with `.beads/`

After this lands, fresh clones will not have `.beads/`. Users who want to use `bd` locally run `bd init` (or `gt rig add`) themselves; their state stays local.

## Org-wide context

One slice of an org-wide cleanup coordinated across the gas-town mesh:
- **Yggdrasil**: full-rip on consumer repos (this PR + DataViking-Tech/traitprint#31).
- **Midgard**: selective-rip on template/fixture repos (gastown-dev, gc-sandbox, dv-city).
- **Jotunheim**: hard-rip on ultra-sandbox.

Shape was consensus'd across the three mayors after a multi-step consult; overseer greenlit on 2026-05-06.

## Test plan

- [ ] CI green on this branch (no test changes; only file deletions in an ignored path)
- [ ] After merge, fresh git clone of main does not produce a .beads/ directory
- [ ] gt rig add against the post-merge repo no longer hits the issue_prefix collision

Generated with Claude Code